### PR TITLE
Adjusted call to _client.send in GenericSyncClient to fix issue with …

### DIFF
--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -55,11 +55,11 @@ class WatchDriver:
         self._build_request = build_request
         self._lazy = lazy
 
-    def get_request(self):
+    def get_request(self, timeout):
         br = self._br
         if self._version is not None:
             br.params['resourceVersion'] = self._version
-        return self._build_request(br.method, br.url, params=br.params)
+        return self._build_request(br.method, br.url, params=br.params, timeout=timeout)
 
     def process_one_line(self, line):
         line = json.loads(line)
@@ -207,7 +207,7 @@ class GenericSyncClient(GenericClient):
         wd = WatchDriver(br, self._client.build_request, self._lazy)
         err_count = 0
         while True:
-            req = wd.get_request()
+            req = wd.get_request(timeout=self._watch_timeout)
             resp = self.send(req, stream=True)
             try:
                 resp.raise_for_status()
@@ -251,7 +251,7 @@ class GenericAsyncClient(GenericClient):
         wd = WatchDriver(br, self._client.build_request, self._lazy)
         err_count = 0
         while True:
-            req = wd.get_request()
+            req = wd.get_request(timeout=self._watch_timeout)
             resp = await self.send(req, stream=True)
             try:
                 resp.raise_for_status()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-httpx >= 0.18.1
+httpx >= 0.20.0
 pytest
 pytest-asyncio
 respx


### PR DESCRIPTION
I've seen an issue in a couple of places:

```
Traceback (most recent call last):
  ...
  File "/var/lib/juju/agents/unit-prometheus-0/charm/venv/lightkube/core/generic_client.py", line 232, in request
    resp = self.send(req)
  File "/var/lib/juju/agents/unit-prometheus-0/charm/venv/lightkube/core/generic_client.py", line 204, in send
    return self._client.send(req, stream=stream, timeout=self._watch_timeout if stream else None)
TypeError: send() got an unexpected keyword argument 'timeout'
```

I also observed a test failure with the same issue while running the CI in my branch for #10. This PR fixes that, though is proposed for discussion, as I don't fully understand the wider consequences of this change. Up front, it fixes the issue on my side, and the tests seem to pass, but there may be context I'm missing. 

There has been an upstream package change that could have caused this, and pinning to an older version of `httpx` could solve it for now, though is likely not a great strategy going forward, I guess!
