### PR TITLE
Include the `py.typed` in the `package_data`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     license='MIT',
     url='https://github.com/gtsystem/lightkube',
     packages=['lightkube', 'lightkube.config', 'lightkube.core'],
+    package_data={'lightkube': ['py.typed']},
     install_requires=[
         'lightkube-models >= 1.15.12.0',
         'httpx >= 0.20.0',


### PR DESCRIPTION
I think [according to the docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages) this package is missing an entry in the `setup.py` to include the `py.typed`.

What I can't quite figure out, is if there should also be a `py.typed` in `lightkube/config` and `lightkube/core` given that they are stated as packages themselves, but either way this is a start ;)

Thanks :)