### PR TITLE
Add client.wait method

### DIFF
--- a/lightkube/core/exceptions.py
+++ b/lightkube/core/exceptions.py
@@ -26,3 +26,29 @@ class LoadResourceError(Exception):
     """
     Error in loading a resource
     """
+
+
+class ObjectDeleted(Exception):
+    """
+    Object was unexpectedly deleted
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def __str__(self):
+        return f"{self.name} was unexpectedly deleted"
+
+
+class ConditionError(Exception):
+    """
+    Object is in specified bad condition
+    """
+
+    def __init__(self, name, messages):
+        self.name = name
+        self.messages = messages
+
+    def __str__(self):
+        messages = '; '.join(self.messages)
+        return f'{self.name} has failure condition(s): {messages}'


### PR DESCRIPTION
Adds `client.wait` as a rough analogue of `kubectl wait`. Builds on top of `client.watch` to wait for specified resource to enter expected state.

Opening as draft PR to ensure that this is something that is generally desired in lightkube. If so, will also implement logic for `AsyncClient` and convert to regular PR.

Punts on implementing an equivalent of `kubectl wait`'s `--timeout` flag, as that would require some deeper changes in how exactly the watch requests are handled. Some extra logic around [`stream=True`](https://github.com/gtsystem/lightkube/blob/436126f/lightkube/core/generic_client.py#L211) and setting the [read timeout](https://github.com/gtsystem/lightkube/blob/436126f/lightkube/core/generic_client.py#L80) should work if that's desired, but this PR also includes an example of how to achieve the same thing with `gevent.Timeout`.