### PR TITLE
Apply command

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,36 @@ obj = Deployment.Scale(
 client.replace(obj, 'metrics-server', namespace='kube-system')
 ```
 
+Create and modify resources using [server side apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+
+*Note:* `field_manager` is required for server-side apply. You can specify it once in the client constructor
+or when calling `apply()`. Also `apiVersion` and `kind` need to be provided as part of
+the object definition.
+
+```python
+from lightkube.resources.core_v1 import ConfigMap
+from lightkube.models.meta_v1 import ObjectMeta
+
+client = Client(field_manager="my-manager")
+config = ConfigMap(
+    # note apiVersion and kind need to be specified for server-side apply
+    apiVersion='v1', kind='ConfigMap',
+    metadata=ObjectMeta(name='my-config', namespace='default'),
+    data={'key1': 'value1', 'key2': 'value2'}
+)
+
+res = client.apply(config)
+print(res.data)
+# prints {'key1': 'value1', 'key2': 'value2'}
+
+del config.data['key1']
+config.data['key3'] = 'value3'
+
+res = client.apply(config)
+print(res.data)
+# prints {'key2': 'value2', 'key3': 'value3'}
+```
+
 Stream pod logs
 ```python
 from lightkube import Client

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -34,12 +34,14 @@ class Client:
       is ignored when watching changes.
     * **lazy** - When set, the returned objects will be decoded from the JSON payload in a lazy way, i.e. only when
       accessed.
+    * **field_manager** - Name associated with the actor or entity that is making these changes.
     * **trust_env** - Ignore environment variables, also passed through to httpx.Client trust_env.  See its
       docs for further description. If False, empty config will be derived from_file(DEFAULT_KUBECONFIG)
     """
     def __init__(self, config: Union[SingleConfig, KubeConfig] = None, namespace: str = None,
-                 timeout: httpx.Timeout = None, lazy=True, trust_env: bool = True):
-        self._client = GenericSyncClient(config, namespace=namespace, timeout=timeout, lazy=lazy, trust_env=trust_env)
+                 timeout: httpx.Timeout = None, lazy=True, field_manager: str = None, trust_env: bool = True):
+        self._client = GenericSyncClient(config, namespace=namespace, timeout=timeout, lazy=lazy,
+                                         field_manager=field_manager, trust_env=trust_env)
 
     @property
     def namespace(self):
@@ -378,12 +380,14 @@ class AsyncClient:
       is ignored when watching changes.
     * **lazy** - When set, the returned objects will be decoded from the JSON payload in a lazy way, i.e. only when
       accessed.
+    * **field_manager** - Name associated with the actor or entity that is making these changes.
     * **trust_env** - Ignore environment variables, also passed through to httpx.AsyncClient trust_env.  See its
       docs for further description. If False, empty config will be derived from_file(DEFAULT_KUBECONFIG)
     """
     def __init__(self, config: Union[SingleConfig, KubeConfig] = None, namespace: str = None,
-                 timeout: httpx.Timeout = None, lazy=True, trust_env: bool = True):
-        self._client = GenericAsyncClient(config, namespace=namespace, timeout=timeout, lazy=lazy, trust_env=trust_env)
+                 timeout: httpx.Timeout = None, lazy=True, field_manager: str = None, trust_env: bool = True):
+        self._client = GenericAsyncClient(config, namespace=namespace, timeout=timeout, lazy=lazy,
+                                          field_manager=field_manager, trust_env=trust_env)
 
     @property
     def namespace(self):

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -297,22 +297,23 @@ class Client:
 
 
     @overload
-    def create(self, obj: GlobalSubResource,  name: str) -> GlobalSubResource:
+    def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None) -> NamespacedSubResource:
+    def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    def create(self, obj: GlobalResource) -> GlobalResource:
+    def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    def create(self, obj: NamespacedResource) -> NamespacedResource:
+    def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
-    def create(self, obj, name=None, *, namespace=None):
+    def create(self, obj, name=None, *, namespace=None, field_manager=None):
         """Creates a new object
 
         **parameters**
@@ -320,26 +321,30 @@ class Client:
         * **obj** - object to create. This need to be an instance of a resource kind.
         * **name** - *(optional)* Required only for sub-resources: Name of the resource to which this object belongs.
         * **namespace** - *(optional)* Name of the namespace containing the object (Only for namespaced resources).
+        * **field_manager** - *(optional)* Name associated with the actor or entity that is making these changes.
+            This parameter overrides the corresponding `Client` initialization parameter.
         """
-        return self._client.request("post", name=name, namespace=namespace, obj=obj)
+        return self._client.request("post", name=name, namespace=namespace, obj=obj,
+                                    params={'fieldManager': field_manager})
 
     @overload
-    def replace(self, obj: GlobalSubResource, name: str) -> GlobalSubResource:
+    def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None) -> NamespacedSubResource:
+    def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    def replace(self, obj: GlobalResource) -> GlobalResource:
+    def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    def replace(self, obj: NamespacedResource) -> NamespacedResource:
+    def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
-    def replace(self, obj, name=None, *, namespace=None):
+    def replace(self, obj, name=None, *, namespace=None, field_manager=None):
         """Replace an existing resource.
 
         **parameters**
@@ -347,8 +352,11 @@ class Client:
         * **obj** - new object. This need to be an instance of a resource kind.
         * **name** - *(optional)* Required only for sub-resources: Name of the resource to which this object belongs.
         * **namespace** - *(optional)* Name of the namespace containing the object (Only for namespaced resources).
+        * **field_manager** - *(optional)* Name associated with the actor or entity that is making these changes.
+            This parameter overrides the corresponding `Client` initialization parameter.
         """
-        return self._client.request("put", name=name, namespace=namespace, obj=obj)
+        return self._client.request("put", name=name, namespace=namespace, obj=obj,
+                                    params={'fieldManager': field_manager})
 
     @overload
     def log(self, name:str, *, namespace: str = None, container: str = None, follow: bool = False,
@@ -692,22 +700,23 @@ class AsyncClient:
                                           params={'force': force_param, 'fieldManager': field_manager})
 
     @overload
-    async def create(self, obj: GlobalSubResource,  name: str) -> GlobalSubResource:
+    async def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    async def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None) -> NamespacedSubResource:
+    async def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    async def create(self, obj: GlobalResource) -> GlobalResource:
+    async def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    async def create(self, obj: NamespacedResource) -> NamespacedResource:
+    async def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
-    async def create(self, obj, name=None, *, namespace=None):
+    async def create(self, obj, name=None, *, namespace=None, field_manager=None):
         """Creates a new object
 
         **parameters**
@@ -715,26 +724,30 @@ class AsyncClient:
         * **obj** - object to create. This need to be an instance of a resource kind.
         * **name** - *(optional)* Required only for sub-resources: Name of the resource to which this object belongs.
         * **namespace** - *(optional)* Name of the namespace containing the object (Only for namespaced resources).
+        * **field_manager** - *(optional)* Name associated with the actor or entity that is making these changes.
+            This parameter overrides the corresponding `Client` initialization parameter.
         """
-        return await self._client.request("post", name=name, namespace=namespace, obj=obj)
+        return await self._client.request("post", name=name, namespace=namespace, obj=obj,
+                                          params={'fieldManager': field_manager})
 
     @overload
-    async def replace(self, obj: GlobalSubResource, name: str) -> GlobalSubResource:
+    async def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None) -> NamespacedSubResource:
+    async def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
+                      field_manager: str = None) -> NamespacedSubResource:
         ...
 
     @overload
-    async def replace(self, obj: GlobalResource) -> GlobalResource:
+    async def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedResource) -> NamespacedResource:
+    async def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
-    async def replace(self, obj, name=None, *, namespace=None):
+    async def replace(self, obj, name=None, *, namespace=None, field_manager=None):
         """Replace an existing resource.
 
         **parameters**
@@ -742,8 +755,11 @@ class AsyncClient:
         * **obj** - new object. This need to be an instance of a resource kind.
         * **name** - *(optional)* Required only for sub-resources: Name of the resource to which this object belongs.
         * **namespace** - *(optional)* Name of the namespace containing the object (Only for namespaced resources).
+        * **field_manager** - *(optional)* Name associated with the actor or entity that is making these changes.
+            This parameter overrides the corresponding `Client` initialization parameter.
         """
-        return await self._client.request("put", name=name, namespace=namespace, obj=obj)
+        return await self._client.request("put", name=name, namespace=namespace, obj=obj,
+                                          params={'fieldManager': field_manager})
 
     @overload
     def log(self, name:str, *, namespace: str = None, container: str = None, follow: bool = False,

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -149,6 +149,8 @@ class GenericClient:
         if method in ('post', 'put', 'patch'):
             if self._field_manager is not None and 'fieldManager' not in params:
                 params['fieldManager'] = self._field_manager
+            if method == 'patch' and headers['Content-Type'] == PatchType.APPLY.value and 'fieldManager' not in params:
+                raise ValueError('Parameter "field_manager" is required for PatchType.APPLY')
             if obj is None:
                 raise ValueError("obj is required for post, put or patch")
 
@@ -229,8 +231,9 @@ class GenericSyncClient(GenericClient):
                     time.sleep(handle_error.sleep)
                 continue
 
-    def request(self, method, res: Type[r.Resource] = None, obj=None, name=None, namespace=None, watch: bool = False, headers: dict = None) -> Any:
-        br = self.prepare_request(method, res, obj, name, namespace, watch, headers=headers)
+    def request(self, method, res: Type[r.Resource] = None, obj=None, name=None, namespace=None, watch: bool = False,
+                headers: dict = None, params: dict = None) -> Any:
+        br = self.prepare_request(method, res, obj, name, namespace, watch, headers=headers, params=params)
         req = self.build_adapter_request(br)
         resp = self.send(req)
         return self.handle_response(method, resp, br)
@@ -272,8 +275,9 @@ class GenericAsyncClient(GenericClient):
                     await asyncio.sleep(handle_error.sleep)
                 continue
 
-    async def request(self, method, res: Type[r.Resource] = None, obj=None, name=None, namespace=None, watch: bool = False, headers: dict = None) -> Any:
-        br = self.prepare_request(method, res, obj, name, namespace, watch, headers=headers)
+    async def request(self, method, res: Type[r.Resource] = None, obj=None, name=None, namespace=None,
+                      watch: bool = False, headers: dict = None, params: dict = None) -> Any:
+        br = self.prepare_request(method, res, obj, name, namespace, watch, headers=headers, params=params)
         req = self.build_adapter_request(br)
         resp = await self.send(req)
         return self.handle_response(method, resp, br)

--- a/lightkube/types.py
+++ b/lightkube/types.py
@@ -2,10 +2,12 @@ import enum
 from dataclasses import dataclass
 import typing
 
+
 class PatchType(enum.Enum):
     JSON = 'application/json-patch+json'
     MERGE = 'application/merge-patch+json'
     STRATEGIC = 'application/strategic-merge-patch+json'
+    APPLY = 'application/apply-patch+yaml'
 
 
 class OnErrorAction(enum.Enum):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -447,6 +447,10 @@ def test_field_manager(kubeconfig):
         json={'metadata': {'name': 'xy'}})
     client.replace(Pod(metadata=ObjectMeta(name="xy")))
 
+    respx.put("https://localhost:9443/api/v1/namespaces/default/pods/xy?fieldManager=override").respond(
+        json={'metadata': {'name': 'xy'}})
+    client.replace(Pod(metadata=ObjectMeta(name="xy")), field_manager='override')
+
 
 @respx.mock
 def test_create_namespaced(client: lightkube.Client):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -379,25 +379,57 @@ def test_wait_custom(client: lightkube.Client):
 
 @respx.mock
 def test_patch_namespaced(client: lightkube.Client):
+    # Default PatchType.STRATEGIC
     req = respx.patch("https://localhost:9443/api/v1/namespaces/default/pods/xx").respond(json={'metadata': {'name': 'xx'}})
     pod = client.patch(Pod, "xx", Pod(metadata=ObjectMeta(labels={'l': 'ok'})))
     assert pod.metadata.name == 'xx'
     assert req.calls[0][0].headers['Content-Type'] == "application/strategic-merge-patch+json"
 
+    # PatchType.MERGE
     req = respx.patch("https://localhost:9443/api/v1/namespaces/other/pods/xx").respond(json={'metadata': {'name': 'xx'}})
     pod = client.patch(Pod, "xx", Pod(metadata=ObjectMeta(labels={'l': 'ok'})), namespace='other',
-                       patch_type=types.PatchType.MERGE)
+                       patch_type=types.PatchType.MERGE, force=True)
     assert pod.metadata.name == 'xx'
     assert req.calls[0][0].headers['Content-Type'] == "application/merge-patch+json"
+    assert 'force' not in str(req.calls[0][0].url)  # force is ignored for non APPLY patch types
+
+    # PatchType.APPLY
+    req = respx.patch("https://localhost:9443/api/v1/namespaces/other/pods/xy?fieldManager=test").respond(
+        json={'metadata': {'name': 'xy'}})
+    pod = client.patch(Pod, "xy", Pod(metadata=ObjectMeta(labels={'l': 'ok'})), namespace='other',
+                       patch_type=types.PatchType.APPLY, field_manager='test')
+    assert pod.metadata.name == 'xy'
+    assert req.calls[0][0].headers['Content-Type'] == "application/apply-patch+yaml"
+
+    # PatchType.APPLY + force
+    req = respx.patch("https://localhost:9443/api/v1/namespaces/other/pods/xz?fieldManager=test&force=true").respond(
+        json={'metadata': {'name': 'xz'}})
+    pod = client.patch(Pod, "xz", Pod(metadata=ObjectMeta(labels={'l': 'ok'})), namespace='other',
+                       patch_type=types.PatchType.APPLY, field_manager='test', force=True)
+    assert pod.metadata.name == 'xz'
+    assert req.calls[0][0].headers['Content-Type'] == "application/apply-patch+yaml"
+
+    # PatchType.APPLY without field_manager
+    with pytest.raises(ValueError, match="field_manager"):
+        client.patch(Pod, "xz", Pod(metadata=ObjectMeta(labels={'l': 'ok'})), namespace='other',
+                     patch_type=types.PatchType.APPLY)
 
 
 @respx.mock
 def test_patch_global(client: lightkube.Client):
     req = respx.patch("https://localhost:9443/api/v1/nodes/xx").respond(json={'metadata': {'name': 'xx'}})
-    pod = client.patch(Node, "xx", [{"op": "add", "path": "/metadata/labels/x", "value": "y"}],
-                       patch_type=types.PatchType.JSON)
-    assert pod.metadata.name == 'xx'
+    node = client.patch(Node, "xx", [{"op": "add", "path": "/metadata/labels/x", "value": "y"}],
+                        patch_type=types.PatchType.JSON)
+    assert node.metadata.name == 'xx'
     assert req.calls[0][0].headers['Content-Type'] == "application/json-patch+json"
+
+    # PatchType.APPLY + force
+    req = respx.patch("https://localhost:9443/api/v1/nodes/xy?fieldManager=test&force=true").respond(
+        json={'metadata': {'name': 'xy'}})
+    node = client.patch(Node, "xy", Pod(metadata=ObjectMeta(labels={'l': 'ok'})),
+                        patch_type=types.PatchType.APPLY, field_manager='test', force=True)
+    assert node.metadata.name == 'xy'
+    assert req.calls[0][0].headers['Content-Type'] == "application/apply-patch+yaml"
 
 
 @respx.mock


### PR DESCRIPTION
This PR addresses issue #16 and adds a new method to the client for creating and editing objects using server side apply operation. Server side apply is now supported in `Client.patch()` as well.
Furthermore `field_manager` can now be set in the client constructor or in one of the write methods (`Client.create()`, `Client.patch()`, `Client.replace()`, `Client.apply`). 