### PR TITLE
Bug fix: Fix issue with CRD listing. 

### DIFF
--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -194,7 +194,7 @@ class GenericClient:
             return
         data = resp.json()
         if method == 'list':
-            if 'metadata' in data and 'continue' in data['metadata']:
+            if 'metadata' in data and data['metadata'].get('continue'):
                 cont = True
                 br.params['continue'] = data['metadata']['continue']
             else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name='lightkube',
-    version="0.10.0",
+    version="0.10.1",
     description='Lightweight kubernetes client library',
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -144,6 +144,15 @@ def test_list_namespaced(client: lightkube.Client):
 
 
 @respx.mock
+def test_list_crd(client: lightkube.Client):
+    """CRD list seems to return always the 'continue' metadata attribute"""
+    resp = {'items': [{'metadata': {'name': 'xx'}}, {'metadata': {'name': 'yy'}}], 'metadata': {'continue': ''}}
+    respx.get("https://localhost:9443/api/v1/namespaces/default/pods").respond(json=resp)
+    pods = client.list(Pod)
+    assert [pod.metadata.name for pod in pods] == ['xx', 'yy']
+
+
+@respx.mock
 def test_list_global(client: lightkube.Client):
     resp = {'items': [{'metadata': {'name': 'xx'}}, {'metadata': {'name': 'yy'}}]}
     respx.get("https://localhost:9443/api/v1/nodes").respond(json=resp)


### PR DESCRIPTION
It seems k8s always send the `continue` attribute (but with an empty string value) for this kind of resources.

Fixes #25