### PR TITLE
Simplify custom resources creation

### DIFF
--- a/e2e-tests/test-crd.yaml
+++ b/e2e-tests/test-crd.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabs.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabs
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontab
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTab
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - ct

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -158,6 +158,12 @@ class GenericClient:
                 data = obj
             else:
                 data = obj.to_dict()
+                # The following block, ensures that apiVersion and kind are always set.
+                # this is needed as k8s fails if this data are not provided for objects derived by CRDs (Issue #27)
+                if 'apiVersion' not in data:
+                    data['apiVersion'] = api_info.resource.api_version
+                if 'kind' not in data:
+                    data['kind'] = api_info.resource.kind
 
         path.append(api_info.plural)
         if method in ('delete', 'get', 'patch', 'put') or api_info.action:

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -280,6 +280,8 @@ class GenericAsyncClient(GenericClient):
                 if handle_error.sleep > 0:
                     await asyncio.sleep(handle_error.sleep)
                 continue
+            finally:
+                await resp.aclose()
 
     async def request(self, method, res: Type[r.Resource] = None, obj=None, name=None, namespace=None,
                       watch: bool = False, headers: dict = None, params: dict = None) -> Any:

--- a/lightkube/core/resource.py
+++ b/lightkube/core/resource.py
@@ -7,6 +7,10 @@ class ResourceDef(NamedTuple):
     version: str
     kind: str
 
+    @property
+    def api_version(self):
+        return f"{self.group}/{self.version}" if self.group else self.version
+
 
 @dataclass
 class ApiInfo:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name='lightkube',
-    version="0.10.1",
+    version="0.10.2",
     description='Lightweight kubernetes client library',
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -14,7 +14,8 @@ from lightkube.generic_resource import create_global_resource
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube import types
 
-from .test_client import make_wait_custom, make_wait_deleted, make_wait_failed, make_wait_success, make_watch_list
+from .test_client import make_wait_custom, make_wait_deleted, make_wait_failed, make_wait_success, make_watch_list, \
+    json_contains
 
 KUBECONFIG = """
 apiVersion: v1
@@ -256,7 +257,7 @@ async def test_patch_global(client: lightkube.AsyncClient):
 async def test_create_global(client: lightkube.AsyncClient):
     req = respx.post("https://localhost:9443/api/v1/nodes").respond(json={'metadata': {'name': 'xx'}})
     pod = await client.create(Node(metadata=ObjectMeta(name="xx")))
-    assert req.calls[0][0].read() == b'{"metadata": {"name": "xx"}}'
+    json_contains(req.calls[0][0].read(), {"metadata": {"name": "xx"}})
     assert pod.metadata.name == 'xx'
     await client.close()
 
@@ -266,7 +267,7 @@ async def test_create_global(client: lightkube.AsyncClient):
 async def test_replace_global(client: lightkube.AsyncClient):
     req = respx.put("https://localhost:9443/api/v1/nodes/xx").respond(json={'metadata': {'name': 'xx'}})
     pod = await client.replace(Node(metadata=ObjectMeta(name="xx")))
-    assert req.calls[0][0].read() == b'{"metadata": {"name": "xx"}}'
+    json_contains(req.calls[0][0].read() , {"metadata": {"name": "xx"}})
     assert pod.metadata.name == 'xx'
     await client.close()
 

--- a/tests/test_generic_resource.py
+++ b/tests/test_generic_resource.py
@@ -4,9 +4,11 @@ from lightkube import generic_resource as gr
 from lightkube.core.generic_client import GenericClient
 from lightkube.models.meta_v1 import ObjectMeta
 
+
 class MockedClient(GenericClient):
     def __init__(self):
         self.namespace = 'default'
+        self._field_manager = None
 
 
 def test_create_namespaced_resource():
@@ -21,6 +23,11 @@ def test_create_namespaced_resource():
     pr = c.prepare_request('list', Test, namespace='myns')
     assert pr.method == 'GET'
     assert pr.url == 'apis/test.eu/v1/namespaces/myns/tests'
+
+    pr = c.prepare_request('post', obj=Test(metadata={'namespace': 'myns'}, spec={'a': 1}))
+    assert pr.method == 'POST'
+    assert pr.url == 'apis/test.eu/v1/namespaces/myns/tests'
+    assert pr.data == {'apiVersion': 'test.eu/v1', 'kind': 'TestN', 'spec': {'a': 1}, 'metadata': {'namespace': 'myns'}}
 
     pr = c.prepare_request('get', Test.Scale, name='xx', namespace='myns')
     assert pr.method == 'GET'
@@ -43,6 +50,11 @@ def test_create_global_resource():
     pr = c.prepare_request('list', Test)
     assert pr.method == 'GET'
     assert pr.url == 'apis/test.eu/v1/tests'
+
+    pr = c.prepare_request('post', obj=Test(spec={'a': 1}))
+    assert pr.method == 'POST'
+    assert pr.url == 'apis/test.eu/v1/tests'
+    assert pr.data == {'apiVersion': 'test.eu/v1', 'kind': 'TestG', 'spec': {'a': 1}}
 
     pr = c.prepare_request('get', Test.Scale, name='xx')
     assert pr.method == 'GET'


### PR DESCRIPTION
Closes #27. Lightkube now always try to set `apiVersion` and `kind` (if not specified already) before creating/replacing resources. These attributes are extracted from the Resource definition.