### PR TITLE
Add `sort_objects()` to make batch resource actions simpler

### DIFF
--- a/lightkube/__init__.py
+++ b/lightkube/__init__.py
@@ -1,4 +1,5 @@
 from .core.client import Client, AsyncClient
 from .core.generic_client import ALL_NS
 from .core.exceptions import ApiError, ConfigError, LoadResourceError
+from .core.sort_objects import sort_objects
 from .config.kubeconfig import KubeConfig, SingleConfig

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import Type, Iterator, TypeVar, Union, overload, Dict, Tuple, List, Iterable, AsyncIterable
 import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
@@ -840,3 +841,55 @@ class AsyncClient:
     async def close(self):
         """Close the underline httpx client"""
         await self._client.close()
+
+
+def sort_objects(objs: List[r.Resource], by: str="kind", reverse=False) -> List[r.Resource]:
+    """Sorts a list of resource objects by a sorting schema, returning a new list
+
+    **parameters**
+    * **objs** - list of resource objects to be sorted
+    * **by** - *(optional)* sorting schema. Possible values:
+        * **kind** - sorts by kind, ranking objects in an order that is suitable for batch-applying
+          many resources.  For example, Namespaces and ServiceAccounts are sorted ahead of
+          ClusterRoleBindings or Pods that might use them.  The reverse of this order is suitable
+          for batch-deleting.
+          See _kind_rank_function for full details on sorting
+    * **reverse** - *(optional)* if `True`, sorts in reverse order
+    """
+    if by == "kind":
+        objs = sorted(objs, key=_kind_rank_function, reverse=reverse)
+    else:
+        raise ValueError(f"Unknown sorting schema: {by}")
+    return objs
+
+
+UNKNOWN_ITEM_SORT_VALUE = 1000
+APPLY_ORDER = defaultdict(lambda: UNKNOWN_ITEM_SORT_VALUE)
+APPLY_ORDER["CustomResourceDefinition"] = 10
+APPLY_ORDER["Namespace"] = 20
+APPLY_ORDER["Secret"] = 31
+APPLY_ORDER["ServiceAccount"] = 32
+APPLY_ORDER["PersistentVolume"] = 33
+APPLY_ORDER["PersistentVolumeClaim"] = 34
+APPLY_ORDER["ConfigMap"] = 35
+APPLY_ORDER["Role"] = 41
+APPLY_ORDER["ClusterRole"] = 42
+APPLY_ORDER["RoleBinding"] = 43
+APPLY_ORDER["ClusterRoleBinding"] = 44
+# apply_order[anything_else] = unknown_item_sort_value
+
+
+def _kind_rank_function(obj: List[r.Resource]) -> int:
+    """
+    Returns an integer rank based on an objects .kind
+
+    Ranking is set to order kinds by:
+    * CRDs
+    * Namespaces
+    * Things that might be referenced by pods (Secret, ServiceAccount, PVs/PVCs, ConfigMap)
+    * RBAC
+        * Roles and ClusterRoles
+        * RoleBindings and ClusterRoleBindings
+    * Everything else (Pod, Deployment, ...)
+    """
+    return APPLY_ORDER[obj.kind]

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -452,16 +452,15 @@ class Client:
 
         for i, obj in enumerate(objs):
             if isinstance(obj, NamespacedResource):
-                namespace = obj.metadata.namespace
+                returns[i] = self.apply(obj, namespace=obj.metadata.namespace, field_manager=field_manager, force=force)
             elif isinstance(obj, GlobalResource):
-                namespace = None
+                returns[i] = self.apply(obj, field_manager=field_manager, force=force)
             else:
                 raise TypeError("apply_many only supports objects of types NamespacedResource or GlobalResource")
-            returns[i] = self.apply(obj, namespace=namespace, field_manager=field_manager, force=force)
         return returns
 
 def _sort_for_apply(
-        objs: Iterable[
+        objs: List[
             Union[
                 GlobalSubResourceTypeVar,
                 NamespacedSubResourceTypeVar,
@@ -478,7 +477,7 @@ def _sort_for_apply(
     ]
 ]:
     """
-    Returns a list of Resource types, sorted into an order that is safe to apply with
+    Returns a list of Resource types, sorted into an order that is safe to apply
 
     See _kind_rank_function for sorting order
     """

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -90,29 +90,6 @@ class Client:
         """
         return self._client.request("deletecollection", res=res, namespace=namespace)
 
-    def delete_many(self, objs: Iterable[Union[GlobalResourceTypeVar, NamespacedResourceTypeVar]]) -> None:
-        """Delete an iterable of objects using client.delete()
-
-        To avoid deleting objects that are being used by others in the list (eg: deleting a CRD before deleting the CRs),
-        resources are deleted in the reverse order as defined in apply_many
-
-        **parameters**
-
-        * **objs** - iterable of objects to delete. This need to be instances of a resource kind and have
-          resource.metadata.namespaced defined if they are namespaced resources
-        """
-        objs = _sort_for_delete(objs)
-
-        for i, obj in enumerate(objs):
-            if isinstance(obj, NamespacedResource):
-                namespace = obj.metadata.namespace
-            elif isinstance(obj, GlobalResource):
-                namespace = None
-            else:
-                raise TypeError("delete_many only supports objects of types NamespacedResource or GlobalResource")
-
-            self.delete(obj, name=obj.metadata.name, namespace=namespace)
-
     @overload
     def get(self, res: Type[GlobalResourceTypeVar], name: str) -> GlobalResourceTypeVar:
         ...
@@ -506,30 +483,6 @@ def _sort_for_apply(
     See _kind_rank_function for sorting order
     """
     return sorted(objs, key=_kind_rank_function)
-
-def _sort_for_delete(
-        objs: Iterable[
-            Union[
-                GlobalSubResourceTypeVar,
-                NamespacedSubResourceTypeVar,
-                GlobalResourceTypeVar,
-                NamespacedResourceTypeVar,
-            ]
-        ]
-) -> List[
-    Union[
-        GlobalSubResourceTypeVar,
-        NamespacedSubResourceTypeVar,
-        GlobalResourceTypeVar,
-        NamespacedResourceTypeVar,
-    ]
-]:
-    """
-    Returns a list of Resource types, sorted into an order that is safe to delete with
-
-    See _kind_rank_function for sorting order of apply.  Sorting here is the reverse
-    """
-    return list(reversed(_sort_for_apply(objs)))
 
 unknown_item_sort_value = 1000
 apply_order = defaultdict(lambda: unknown_item_sort_value)

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -9,10 +9,10 @@ from ..types import OnErrorHandler, PatchType, on_error_raise
 from .internal_resources import core_v1
 from .selector import build_selector
 
-NamespacedResourceTypeVar = TypeVar('NamespacedResource', bound=r.NamespacedResource)
-GlobalResourceTypeVar = TypeVar('GlobalResource', bound=r.GlobalResource)
-GlobalSubResourceTypeVar = TypeVar('GlobalSubResource', bound=r.GlobalSubResource)
-NamespacedSubResourceTypeVar = TypeVar('NamespacedSubResource', bound=r.NamespacedSubResource)
+NamespacedResource = TypeVar('NamespacedResource', bound=r.NamespacedResource)
+GlobalResource = TypeVar('GlobalResource', bound=r.GlobalResource)
+GlobalSubResource = TypeVar('GlobalSubResource', bound=r.GlobalSubResource)
+NamespacedSubResource = TypeVar('NamespacedSubResource', bound=r.NamespacedSubResource)
 AllNamespacedResource = TypeVar('AllNamespacedResource', r.NamespacedResource, r.NamespacedSubResource)
 Resource = TypeVar('Resource', bound=r.Resource)
 LabelValue = Union[str, None, operators.Operator, Iterable]
@@ -54,11 +54,11 @@ class Client:
         return self._client.config
 
     @overload
-    def delete(self, res: Type[GlobalResourceTypeVar], name: str) -> None:
+    def delete(self, res: Type[GlobalResource], name: str) -> None:
         ...
 
     @overload
-    def delete(self, res: Type[NamespacedResourceTypeVar], name: str, *, namespace: str = None) -> None:
+    def delete(self, res: Type[NamespacedResource], name: str, *, namespace: str = None) -> None:
         ...
 
     def delete(self, res, name: str, *, namespace: str = None):
@@ -73,11 +73,11 @@ class Client:
         return self._client.request("delete", res=res, name=name, namespace=namespace)
 
     @overload
-    def deletecollection(self, res: Type[GlobalResourceTypeVar]) -> None:
+    def deletecollection(self, res: Type[GlobalResource]) -> None:
         ...
 
     @overload
-    def deletecollection(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None) -> None:
+    def deletecollection(self, res: Type[NamespacedResource], *, namespace: str = None) -> None:
         ...
 
     def deletecollection(self, res, *, namespace: str = None):
@@ -89,7 +89,7 @@ class Client:
         return self._client.request("deletecollection", res=res, namespace=namespace)
 
     @overload
-    def get(self, res: Type[GlobalResourceTypeVar], name: str) -> GlobalResourceTypeVar:
+    def get(self, res: Type[GlobalResource], name: str) -> GlobalResource:
         ...
 
     @overload
@@ -108,14 +108,14 @@ class Client:
         return self._client.request("get", res=res, name=name, namespace=namespace)
 
     @overload
-    def list(self, res: Type[GlobalResourceTypeVar], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            Iterator[GlobalResourceTypeVar]:
+    def list(self, res: Type[GlobalResource], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
+            Iterator[GlobalResource]:
         ...
 
     @overload
-    def list(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None, chunk_size: int = None,
+    def list(self, res: Type[NamespacedResource], *, namespace: str = None, chunk_size: int = None,
              labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            Iterator[NamespacedResourceTypeVar]:
+            Iterator[NamespacedResource]:
         ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
@@ -142,18 +142,18 @@ class Client:
         return self._client.list(br)
 
     @overload
-    def watch(self, res: Type[GlobalResourceTypeVar], *, labels: LabelSelector = None, fields: FieldSelector = None,
+    def watch(self, res: Type[GlobalResource], *, labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None,
               resource_version: str = None, on_error: OnErrorHandler = on_error_raise) -> \
-            Iterator[Tuple[str, GlobalResourceTypeVar]]:
+            Iterator[Tuple[str, GlobalResource]]:
         ...
 
     @overload
-    def watch(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None,
+    def watch(self, res: Type[NamespacedResource], *, namespace: str = None,
               labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None, resource_version: str = None,
               on_error: OnErrorHandler = on_error_raise) -> \
-            Iterator[Tuple[str, NamespacedResourceTypeVar]]:
+            Iterator[Tuple[str, NamespacedResource]]:
         ...
 
     def watch(self, res, *, namespace=None, labels=None, fields=None, server_timeout=None, resource_version=None, on_error=on_error_raise):
@@ -185,12 +185,12 @@ class Client:
     @overload
     def wait(
         self,
-        res: Type[GlobalResourceTypeVar],
+        res: Type[GlobalResource],
         name: str,
         *,
         for_conditions: Iterable[str],
         raise_for_conditions: Iterable[str] = (),
-    ) -> GlobalResourceTypeVar:
+    ) -> GlobalResource:
         ...
 
     @overload
@@ -253,17 +253,17 @@ class Client:
                 raise ConditionError(full_name, [f.get('message', f['type']) for f in failures])
 
     @overload
-    def patch(self, res: Type[GlobalSubResourceTypeVar], name: str,
-              obj: Union[GlobalSubResourceTypeVar, Dict, List], *,
+    def patch(self, res: Type[GlobalSubResource], name: str,
+              obj: Union[GlobalSubResource, Dict, List], *,
               patch_type: PatchType = PatchType.STRATEGIC,
-              field_manager: str = None, force: bool = False) -> GlobalSubResourceTypeVar:
+              field_manager: str = None, force: bool = False) -> GlobalSubResource:
         ...
 
     @overload
-    def patch(self, res: Type[GlobalResourceTypeVar], name: str,
-              obj: Union[GlobalResourceTypeVar, Dict, List], *,
+    def patch(self, res: Type[GlobalResource], name: str,
+              obj: Union[GlobalResource, Dict, List], *,
               patch_type: PatchType = PatchType.STRATEGIC,
-              field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
+              field_manager: str = None, force: bool = False) -> GlobalResource:
         ...
 
     @overload
@@ -297,20 +297,20 @@ class Client:
 
 
     @overload
-    def create(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
+    def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    def create(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResourceTypeVar:
+    def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    def create(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
+    def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    def create(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
+    def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
     def create(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -328,20 +328,20 @@ class Client:
                                     params={'fieldManager': field_manager})
 
     @overload
-    def replace(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
+    def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    def replace(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResourceTypeVar:
+    def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    def replace(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
+    def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    def replace(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
+    def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
     def replace(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -387,21 +387,21 @@ class Client:
         return resp.iter_lines()
 
     @overload
-    def apply(self, obj: GlobalSubResourceTypeVar, name: str, *, field_manager: str = None, force: bool = False) \
-            -> GlobalSubResourceTypeVar:
+    def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \
+            -> GlobalSubResource:
         ...
 
     @overload
-    def apply(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
-              field_manager: str = None, force: bool = False) -> NamespacedSubResourceTypeVar:
+    def apply(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
+              field_manager: str = None, force: bool = False) -> NamespacedSubResource:
         ...
 
     @overload
-    def apply(self, obj: GlobalResourceTypeVar, field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
+    def apply(self, obj: GlobalResource, field_manager: str = None, force: bool = False) -> GlobalResource:
         ...
 
     @overload
-    def apply(self, obj: NamespacedResourceTypeVar, field_manager: str = None, force: bool = False) -> NamespacedResourceTypeVar:
+    def apply(self, obj: NamespacedResource, field_manager: str = None, force: bool = False) -> NamespacedResource:
         ...
 
     def apply(self, obj, name=None, *, namespace=None, field_manager=None, force=False):
@@ -458,11 +458,11 @@ class AsyncClient:
         return self._client.config
 
     @overload
-    async def delete(self, res: Type[GlobalResourceTypeVar], name: str) -> None:
+    async def delete(self, res: Type[GlobalResource], name: str) -> None:
         ...
 
     @overload
-    async def delete(self, res: Type[NamespacedResourceTypeVar], name: str, *, namespace: str = None) -> None:
+    async def delete(self, res: Type[NamespacedResource], name: str, *, namespace: str = None) -> None:
         ...
 
     async def delete(self, res, name: str, *, namespace: str = None):
@@ -477,11 +477,11 @@ class AsyncClient:
         return await self._client.request("delete", res=res, name=name, namespace=namespace)
 
     @overload
-    async def deletecollection(self, res: Type[GlobalResourceTypeVar]) -> None:
+    async def deletecollection(self, res: Type[GlobalResource]) -> None:
         ...
 
     @overload
-    async def deletecollection(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None) -> None:
+    async def deletecollection(self, res: Type[NamespacedResource], *, namespace: str = None) -> None:
         ...
 
     async def deletecollection(self, res, *, namespace: str = None):
@@ -493,7 +493,7 @@ class AsyncClient:
         return await self._client.request("deletecollection", res=res, namespace=namespace)
 
     @overload
-    async def get(self, res: Type[GlobalResourceTypeVar], name: str) -> GlobalResourceTypeVar:
+    async def get(self, res: Type[GlobalResource], name: str) -> GlobalResource:
         ...
 
     @overload
@@ -512,14 +512,14 @@ class AsyncClient:
         return await self._client.request("get", res=res, name=name, namespace=namespace)
 
     @overload
-    def list(self, res: Type[GlobalResourceTypeVar], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            AsyncIterable[GlobalResourceTypeVar]:
+    def list(self, res: Type[GlobalResource], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
+            AsyncIterable[GlobalResource]:
         ...
 
     @overload
-    def list(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None, chunk_size: int = None,
+    def list(self, res: Type[NamespacedResource], *, namespace: str = None, chunk_size: int = None,
              labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            AsyncIterable[NamespacedResourceTypeVar]:
+            AsyncIterable[NamespacedResource]:
         ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
@@ -546,18 +546,18 @@ class AsyncClient:
         return self._client.list(br)
 
     @overload
-    def watch(self, res: Type[GlobalResourceTypeVar], *, labels: LabelSelector = None, fields: FieldSelector = None,
+    def watch(self, res: Type[GlobalResource], *, labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None,
               resource_version: str = None, on_error: OnErrorHandler = on_error_raise) -> \
-            AsyncIterable[Tuple[str, GlobalResourceTypeVar]]:
+            AsyncIterable[Tuple[str, GlobalResource]]:
         ...
 
     @overload
-    def watch(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None,
+    def watch(self, res: Type[NamespacedResource], *, namespace: str = None,
               labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None, resource_version: str = None,
               on_error: OnErrorHandler = on_error_raise) -> \
-            AsyncIterable[Tuple[str, NamespacedResourceTypeVar]]:
+            AsyncIterable[Tuple[str, NamespacedResource]]:
         ...
 
     def watch(self, res, *, namespace=None, labels=None, fields=None, server_timeout=None, resource_version=None, on_error=on_error_raise):
@@ -589,12 +589,12 @@ class AsyncClient:
     @overload
     async def wait(
         self,
-        res: Type[GlobalResourceTypeVar],
+        res: Type[GlobalResource],
         name: str,
         *,
         for_conditions: Iterable[str],
         raise_for_conditions: Iterable[str] = (),
-    ) -> GlobalResourceTypeVar:
+    ) -> GlobalResource:
         ...
 
     @overload
@@ -663,17 +663,17 @@ class AsyncClient:
             await watch.aclose()
 
     @overload
-    async def patch(self, res: Type[GlobalSubResourceTypeVar], name: str,
-                    obj: Union[GlobalSubResourceTypeVar, Dict, List], *,
+    async def patch(self, res: Type[GlobalSubResource], name: str,
+                    obj: Union[GlobalSubResource, Dict, List], *,
                     patch_type: PatchType = PatchType.STRATEGIC,
-                    field_manager: str = None, force: bool = False) -> GlobalSubResourceTypeVar:
+                    field_manager: str = None, force: bool = False) -> GlobalSubResource:
         ...
 
     @overload
-    async def patch(self, res: Type[GlobalResourceTypeVar], name: str,
-                    obj: Union[GlobalResourceTypeVar, Dict, List], *,
+    async def patch(self, res: Type[GlobalResource], name: str,
+                    obj: Union[GlobalResource, Dict, List], *,
                     patch_type: PatchType = PatchType.STRATEGIC,
-                    field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
+                    field_manager: str = None, force: bool = False) -> GlobalResource:
         ...
 
     @overload
@@ -706,20 +706,20 @@ class AsyncClient:
                                           params={'force': force_param, 'fieldManager': field_manager})
 
     @overload
-    async def create(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
+    async def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    async def create(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResourceTypeVar:
+    async def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResource:
         ...
 
     @overload
-    async def create(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
+    async def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    async def create(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
+    async def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
     async def create(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -737,20 +737,20 @@ class AsyncClient:
                                           params={'fieldManager': field_manager})
 
     @overload
-    async def replace(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
+    async def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
-                      field_manager: str = None) -> NamespacedSubResourceTypeVar:
+    async def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
+                      field_manager: str = None) -> NamespacedSubResource:
         ...
 
     @overload
-    async def replace(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
+    async def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
+    async def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
         ...
 
     async def replace(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -800,21 +800,21 @@ class AsyncClient:
         return stream_log()
 
     @overload
-    async def apply(self, obj: GlobalSubResourceTypeVar, name: str, *, field_manager: str = None, force: bool = False) \
-            -> GlobalSubResourceTypeVar:
+    async def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \
+            -> GlobalSubResource:
         ...
 
     @overload
-    async def apply(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
-                    field_manager: str = None, force: bool = False) -> NamespacedSubResourceTypeVar:
+    async def apply(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
+              field_manager: str = None, force: bool = False) -> NamespacedSubResource:
         ...
 
     @overload
-    async def apply(self, obj: GlobalResourceTypeVar, field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
+    async def apply(self, obj: GlobalResource, field_manager: str = None, force: bool = False) -> GlobalResource:
         ...
 
     @overload
-    async def apply(self, obj: NamespacedResourceTypeVar, field_manager: str = None, force: bool = False) -> NamespacedResourceTypeVar:
+    async def apply(self, obj: NamespacedResource, field_manager: str = None, force: bool = False) -> NamespacedResource:
         ...
 
     async def apply(self, obj, name=None, *, namespace=None, field_manager=None, force=False):

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Type, Iterator, TypeVar, Union, overload, Dict, Tuple, List, Iterable, AsyncIterable
 import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
@@ -9,7 +8,6 @@ from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, on_error_raise
 from .internal_resources import core_v1
 from .selector import build_selector
-from .resource import NamespacedResource, GlobalResource
 
 NamespacedResourceTypeVar = TypeVar('NamespacedResource', bound=r.NamespacedResource)
 GlobalResourceTypeVar = TypeVar('GlobalResource', bound=r.GlobalResource)
@@ -426,99 +424,6 @@ class Client:
         return self.patch(type(obj), name, obj, namespace=namespace,
                           patch_type=PatchType.APPLY, field_manager=field_manager, force=force)
 
-    def apply_many(self, objs: Iterable[Union[GlobalResourceTypeVar, NamespacedResourceTypeVar]],
-                   field_manager: str = None, force: bool = False) -> None:
-        """Create or configure an iterable of objects using client.apply()
-
-        To avoid referencing objects before they are created, resources are applied in the following order:
-        * CRDs
-        * Namespaces
-        * Things that might be referenced by pods (Secret, ServiceAccount, PVs/PVCs, ConfigMap)
-        * RBAC
-            * Roles and ClusterRoles
-            * RoleBindings and ClusterRoleBindings
-        * Everything else (Pod, Deployment, ...)
-
-        **parameters**
-
-        * **objs** - iterable of objects to create. This need to be instances of a resource kind and have
-          resource.metadata.namespaced defined if they are namespaced resources
-        * **field_manager** - Name associated with the actor or entity that is making these changes.
-        * **force** - *(optional)* Force is going to "force" Apply requests. It means user will re-acquire conflicting
-          fields owned by other people.
-        """
-        objs = _sort_for_apply(objs)
-        returns = [None] * len(objs)
-
-        for i, obj in enumerate(objs):
-            if isinstance(obj, NamespacedResource):
-                returns[i] = self.apply(obj, namespace=obj.metadata.namespace, field_manager=field_manager, force=force)
-            elif isinstance(obj, GlobalResource):
-                returns[i] = self.apply(obj, field_manager=field_manager, force=force)
-            else:
-                raise TypeError("apply_many only supports objects of types NamespacedResource or GlobalResource")
-        return returns
-
-def _sort_for_apply(
-        objs: List[
-            Union[
-                GlobalSubResourceTypeVar,
-                NamespacedSubResourceTypeVar,
-                GlobalResourceTypeVar,
-                NamespacedResourceTypeVar,
-            ]
-        ]
-) -> List[
-    Union[
-        GlobalSubResourceTypeVar,
-        NamespacedSubResourceTypeVar,
-        GlobalResourceTypeVar,
-        NamespacedResourceTypeVar,
-    ]
-]:
-    """
-    Returns a list of Resource types, sorted into an order that is safe to apply
-
-    See _kind_rank_function for sorting order
-    """
-    return sorted(objs, key=_kind_rank_function)
-
-unknown_item_sort_value = 1000
-apply_order = defaultdict(lambda: unknown_item_sort_value)
-apply_order["CustomResourceDefinition"] = 10
-apply_order["Namespace"] = 20
-apply_order["Secret"] = 31
-apply_order["ServiceAccount"] = 32
-apply_order["PersistentVolume"] = 33
-apply_order["PersistentVolumeClaim"] = 34
-apply_order["ConfigMap"] = 35
-apply_order["Role"] = 41
-apply_order["ClusterRole"] = 42
-apply_order["RoleBinding"] = 43
-apply_order["ClusterRoleBinding"] = 44
-# apply_order[anything_else] = unknown_item_sort_value
-
-def _kind_rank_function(
-        obj: Union[
-            GlobalSubResourceTypeVar,
-            NamespacedSubResourceTypeVar,
-            GlobalResourceTypeVar,
-            NamespacedResourceTypeVar,
-        ]
-) -> int:
-    """
-    Returns an integer rank based on an objects .kind
-
-    Ranking is set to order kinds by:
-    * CRDs
-    * Namespaces
-    * Things that might be referenced by pods (Secret, ServiceAccount, PVs/PVCs, ConfigMap)
-    * RBAC
-        * Roles and ClusterRoles
-        * RoleBindings and ClusterRoleBindings
-    * Everything else (Pod, Deployment, ...)
-    """
-    return apply_order[obj.kind]
 
 class AsyncClient:
     """Creates a new lightkube client

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -9,10 +9,10 @@ from ..types import OnErrorHandler, PatchType, on_error_raise
 from .internal_resources import core_v1
 from .selector import build_selector
 
-NamespacedResource = TypeVar('NamespacedResource', bound=r.NamespacedResource)
-GlobalResource = TypeVar('GlobalResource', bound=r.GlobalResource)
-GlobalSubResource = TypeVar('GlobalSubResource', bound=r.GlobalSubResource)
-NamespacedSubResource = TypeVar('NamespacedSubResource', bound=r.NamespacedSubResource)
+NamespacedResourceTypeVar = TypeVar('NamespacedResource', bound=r.NamespacedResource)
+GlobalResourceTypeVar = TypeVar('GlobalResource', bound=r.GlobalResource)
+GlobalSubResourceTypeVar = TypeVar('GlobalSubResource', bound=r.GlobalSubResource)
+NamespacedSubResourceTypeVar = TypeVar('NamespacedSubResource', bound=r.NamespacedSubResource)
 AllNamespacedResource = TypeVar('AllNamespacedResource', r.NamespacedResource, r.NamespacedSubResource)
 Resource = TypeVar('Resource', bound=r.Resource)
 LabelValue = Union[str, None, operators.Operator, Iterable]
@@ -54,11 +54,11 @@ class Client:
         return self._client.config
 
     @overload
-    def delete(self, res: Type[GlobalResource], name: str) -> None:
+    def delete(self, res: Type[GlobalResourceTypeVar], name: str) -> None:
         ...
 
     @overload
-    def delete(self, res: Type[NamespacedResource], name: str, *, namespace: str = None) -> None:
+    def delete(self, res: Type[NamespacedResourceTypeVar], name: str, *, namespace: str = None) -> None:
         ...
 
     def delete(self, res, name: str, *, namespace: str = None):
@@ -73,11 +73,11 @@ class Client:
         return self._client.request("delete", res=res, name=name, namespace=namespace)
 
     @overload
-    def deletecollection(self, res: Type[GlobalResource]) -> None:
+    def deletecollection(self, res: Type[GlobalResourceTypeVar]) -> None:
         ...
 
     @overload
-    def deletecollection(self, res: Type[NamespacedResource], *, namespace: str = None) -> None:
+    def deletecollection(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None) -> None:
         ...
 
     def deletecollection(self, res, *, namespace: str = None):
@@ -89,7 +89,7 @@ class Client:
         return self._client.request("deletecollection", res=res, namespace=namespace)
 
     @overload
-    def get(self, res: Type[GlobalResource], name: str) -> GlobalResource:
+    def get(self, res: Type[GlobalResourceTypeVar], name: str) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -108,14 +108,14 @@ class Client:
         return self._client.request("get", res=res, name=name, namespace=namespace)
 
     @overload
-    def list(self, res: Type[GlobalResource], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            Iterator[GlobalResource]:
+    def list(self, res: Type[GlobalResourceTypeVar], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
+            Iterator[GlobalResourceTypeVar]:
         ...
 
     @overload
-    def list(self, res: Type[NamespacedResource], *, namespace: str = None, chunk_size: int = None,
+    def list(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None, chunk_size: int = None,
              labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            Iterator[NamespacedResource]:
+            Iterator[NamespacedResourceTypeVar]:
         ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
@@ -142,18 +142,18 @@ class Client:
         return self._client.list(br)
 
     @overload
-    def watch(self, res: Type[GlobalResource], *, labels: LabelSelector = None, fields: FieldSelector = None,
+    def watch(self, res: Type[GlobalResourceTypeVar], *, labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None,
               resource_version: str = None, on_error: OnErrorHandler = on_error_raise) -> \
-            Iterator[Tuple[str, GlobalResource]]:
+            Iterator[Tuple[str, GlobalResourceTypeVar]]:
         ...
 
     @overload
-    def watch(self, res: Type[NamespacedResource], *, namespace: str = None,
+    def watch(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None,
               labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None, resource_version: str = None,
               on_error: OnErrorHandler = on_error_raise) -> \
-            Iterator[Tuple[str, NamespacedResource]]:
+            Iterator[Tuple[str, NamespacedResourceTypeVar]]:
         ...
 
     def watch(self, res, *, namespace=None, labels=None, fields=None, server_timeout=None, resource_version=None, on_error=on_error_raise):
@@ -185,12 +185,12 @@ class Client:
     @overload
     def wait(
         self,
-        res: Type[GlobalResource],
+        res: Type[GlobalResourceTypeVar],
         name: str,
         *,
         for_conditions: Iterable[str],
         raise_for_conditions: Iterable[str] = (),
-    ) -> GlobalResource:
+    ) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -253,17 +253,17 @@ class Client:
                 raise ConditionError(full_name, [f.get('message', f['type']) for f in failures])
 
     @overload
-    def patch(self, res: Type[GlobalSubResource], name: str,
-              obj: Union[GlobalSubResource, Dict, List], *,
+    def patch(self, res: Type[GlobalSubResourceTypeVar], name: str,
+              obj: Union[GlobalSubResourceTypeVar, Dict, List], *,
               patch_type: PatchType = PatchType.STRATEGIC,
-              field_manager: str = None, force: bool = False) -> GlobalSubResource:
+              field_manager: str = None, force: bool = False) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    def patch(self, res: Type[GlobalResource], name: str,
-              obj: Union[GlobalResource, Dict, List], *,
+    def patch(self, res: Type[GlobalResourceTypeVar], name: str,
+              obj: Union[GlobalResourceTypeVar, Dict, List], *,
               patch_type: PatchType = PatchType.STRATEGIC,
-              field_manager: str = None, force: bool = False) -> GlobalResource:
+              field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -297,20 +297,20 @@ class Client:
 
 
     @overload
-    def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
+    def create(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResource:
+    def create(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
+    def create(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
+    def create(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
         ...
 
     def create(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -328,20 +328,20 @@ class Client:
                                     params={'fieldManager': field_manager})
 
     @overload
-    def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
+    def replace(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResource:
+    def replace(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
+    def replace(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
+    def replace(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
         ...
 
     def replace(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -387,21 +387,21 @@ class Client:
         return resp.iter_lines()
 
     @overload
-    def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \
-            -> GlobalSubResource:
+    def apply(self, obj: GlobalSubResourceTypeVar, name: str, *, field_manager: str = None, force: bool = False) \
+            -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    def apply(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
-              field_manager: str = None, force: bool = False) -> NamespacedSubResource:
+    def apply(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
+              field_manager: str = None, force: bool = False) -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    def apply(self, obj: GlobalResource, field_manager: str = None, force: bool = False) -> GlobalResource:
+    def apply(self, obj: GlobalResourceTypeVar, field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    def apply(self, obj: NamespacedResource, field_manager: str = None, force: bool = False) -> NamespacedResource:
+    def apply(self, obj: NamespacedResourceTypeVar, field_manager: str = None, force: bool = False) -> NamespacedResourceTypeVar:
         ...
 
     def apply(self, obj, name=None, *, namespace=None, field_manager=None, force=False):
@@ -458,11 +458,11 @@ class AsyncClient:
         return self._client.config
 
     @overload
-    async def delete(self, res: Type[GlobalResource], name: str) -> None:
+    async def delete(self, res: Type[GlobalResourceTypeVar], name: str) -> None:
         ...
 
     @overload
-    async def delete(self, res: Type[NamespacedResource], name: str, *, namespace: str = None) -> None:
+    async def delete(self, res: Type[NamespacedResourceTypeVar], name: str, *, namespace: str = None) -> None:
         ...
 
     async def delete(self, res, name: str, *, namespace: str = None):
@@ -477,11 +477,11 @@ class AsyncClient:
         return await self._client.request("delete", res=res, name=name, namespace=namespace)
 
     @overload
-    async def deletecollection(self, res: Type[GlobalResource]) -> None:
+    async def deletecollection(self, res: Type[GlobalResourceTypeVar]) -> None:
         ...
 
     @overload
-    async def deletecollection(self, res: Type[NamespacedResource], *, namespace: str = None) -> None:
+    async def deletecollection(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None) -> None:
         ...
 
     async def deletecollection(self, res, *, namespace: str = None):
@@ -493,7 +493,7 @@ class AsyncClient:
         return await self._client.request("deletecollection", res=res, namespace=namespace)
 
     @overload
-    async def get(self, res: Type[GlobalResource], name: str) -> GlobalResource:
+    async def get(self, res: Type[GlobalResourceTypeVar], name: str) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -512,14 +512,14 @@ class AsyncClient:
         return await self._client.request("get", res=res, name=name, namespace=namespace)
 
     @overload
-    def list(self, res: Type[GlobalResource], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            AsyncIterable[GlobalResource]:
+    def list(self, res: Type[GlobalResourceTypeVar], *, chunk_size: int = None, labels: LabelSelector = None, fields: FieldSelector = None) -> \
+            AsyncIterable[GlobalResourceTypeVar]:
         ...
 
     @overload
-    def list(self, res: Type[NamespacedResource], *, namespace: str = None, chunk_size: int = None,
+    def list(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None, chunk_size: int = None,
              labels: LabelSelector = None, fields: FieldSelector = None) -> \
-            AsyncIterable[NamespacedResource]:
+            AsyncIterable[NamespacedResourceTypeVar]:
         ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
@@ -546,18 +546,18 @@ class AsyncClient:
         return self._client.list(br)
 
     @overload
-    def watch(self, res: Type[GlobalResource], *, labels: LabelSelector = None, fields: FieldSelector = None,
+    def watch(self, res: Type[GlobalResourceTypeVar], *, labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None,
               resource_version: str = None, on_error: OnErrorHandler = on_error_raise) -> \
-            AsyncIterable[Tuple[str, GlobalResource]]:
+            AsyncIterable[Tuple[str, GlobalResourceTypeVar]]:
         ...
 
     @overload
-    def watch(self, res: Type[NamespacedResource], *, namespace: str = None,
+    def watch(self, res: Type[NamespacedResourceTypeVar], *, namespace: str = None,
               labels: LabelSelector = None, fields: FieldSelector = None,
               server_timeout: int = None, resource_version: str = None,
               on_error: OnErrorHandler = on_error_raise) -> \
-            AsyncIterable[Tuple[str, NamespacedResource]]:
+            AsyncIterable[Tuple[str, NamespacedResourceTypeVar]]:
         ...
 
     def watch(self, res, *, namespace=None, labels=None, fields=None, server_timeout=None, resource_version=None, on_error=on_error_raise):
@@ -589,12 +589,12 @@ class AsyncClient:
     @overload
     async def wait(
         self,
-        res: Type[GlobalResource],
+        res: Type[GlobalResourceTypeVar],
         name: str,
         *,
         for_conditions: Iterable[str],
         raise_for_conditions: Iterable[str] = (),
-    ) -> GlobalResource:
+    ) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -663,17 +663,17 @@ class AsyncClient:
             await watch.aclose()
 
     @overload
-    async def patch(self, res: Type[GlobalSubResource], name: str,
-                    obj: Union[GlobalSubResource, Dict, List], *,
+    async def patch(self, res: Type[GlobalSubResourceTypeVar], name: str,
+                    obj: Union[GlobalSubResourceTypeVar, Dict, List], *,
                     patch_type: PatchType = PatchType.STRATEGIC,
-                    field_manager: str = None, force: bool = False) -> GlobalSubResource:
+                    field_manager: str = None, force: bool = False) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    async def patch(self, res: Type[GlobalResource], name: str,
-                    obj: Union[GlobalResource, Dict, List], *,
+    async def patch(self, res: Type[GlobalResourceTypeVar], name: str,
+                    obj: Union[GlobalResourceTypeVar, Dict, List], *,
                     patch_type: PatchType = PatchType.STRATEGIC,
-                    field_manager: str = None, force: bool = False) -> GlobalResource:
+                    field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
         ...
 
     @overload
@@ -706,20 +706,20 @@ class AsyncClient:
                                           params={'force': force_param, 'fieldManager': field_manager})
 
     @overload
-    async def create(self, obj: GlobalSubResource,  name: str, field_manager: str = None) -> GlobalSubResource:
+    async def create(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    async def create(self, obj: NamespacedSubResource, name: str, *, namespace: str = None, field_manager: str = None) \
-            -> NamespacedSubResource:
+    async def create(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None, field_manager: str = None) \
+            -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    async def create(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
+    async def create(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    async def create(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
+    async def create(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
         ...
 
     async def create(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -737,20 +737,20 @@ class AsyncClient:
                                           params={'fieldManager': field_manager})
 
     @overload
-    async def replace(self, obj: GlobalSubResource, name: str, field_manager: str = None) -> GlobalSubResource:
+    async def replace(self, obj: GlobalSubResourceTypeVar, name: str, field_manager: str = None) -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
-                      field_manager: str = None) -> NamespacedSubResource:
+    async def replace(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
+                      field_manager: str = None) -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    async def replace(self, obj: GlobalResource, field_manager: str = None) -> GlobalResource:
+    async def replace(self, obj: GlobalResourceTypeVar, field_manager: str = None) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    async def replace(self, obj: NamespacedResource, field_manager: str = None) -> NamespacedResource:
+    async def replace(self, obj: NamespacedResourceTypeVar, field_manager: str = None) -> NamespacedResourceTypeVar:
         ...
 
     async def replace(self, obj, name=None, *, namespace=None, field_manager=None):
@@ -800,21 +800,21 @@ class AsyncClient:
         return stream_log()
 
     @overload
-    async def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \
-            -> GlobalSubResource:
+    async def apply(self, obj: GlobalSubResourceTypeVar, name: str, *, field_manager: str = None, force: bool = False) \
+            -> GlobalSubResourceTypeVar:
         ...
 
     @overload
-    async def apply(self, obj: NamespacedSubResource, name: str, *, namespace: str = None,
-              field_manager: str = None, force: bool = False) -> NamespacedSubResource:
+    async def apply(self, obj: NamespacedSubResourceTypeVar, name: str, *, namespace: str = None,
+                    field_manager: str = None, force: bool = False) -> NamespacedSubResourceTypeVar:
         ...
 
     @overload
-    async def apply(self, obj: GlobalResource, field_manager: str = None, force: bool = False) -> GlobalResource:
+    async def apply(self, obj: GlobalResourceTypeVar, field_manager: str = None, force: bool = False) -> GlobalResourceTypeVar:
         ...
 
     @overload
-    async def apply(self, obj: NamespacedResource, field_manager: str = None, force: bool = False) -> NamespacedResource:
+    async def apply(self, obj: NamespacedResourceTypeVar, field_manager: str = None, force: bool = False) -> NamespacedResourceTypeVar:
         ...
 
     async def apply(self, obj, name=None, *, namespace=None, field_manager=None, force=False):

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -452,15 +452,16 @@ class Client:
 
         for i, obj in enumerate(objs):
             if isinstance(obj, NamespacedResource):
-                returns[i] = self.apply(obj, namespace=obj.metadata.namespace, field_manager=field_manager, force=force)
+                namespace = obj.metadata.namespace
             elif isinstance(obj, GlobalResource):
-                returns[i] = self.apply(obj, field_manager=field_manager, force=force)
+                namespace = None
             else:
                 raise TypeError("apply_many only supports objects of types NamespacedResource or GlobalResource")
+            returns[i] = self.apply(obj, namespace=namespace, field_manager=field_manager, force=force)
         return returns
 
 def _sort_for_apply(
-        objs: List[
+        objs: Iterable[
             Union[
                 GlobalSubResourceTypeVar,
                 NamespacedSubResourceTypeVar,
@@ -477,7 +478,7 @@ def _sort_for_apply(
     ]
 ]:
     """
-    Returns a list of Resource types, sorted into an order that is safe to apply
+    Returns a list of Resource types, sorted into an order that is safe to apply with
 
     See _kind_rank_function for sorting order
     """

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Type, Iterator, TypeVar, Union, overload, Dict, Tuple, List, Iterable, AsyncIterable
 import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
@@ -843,53 +842,3 @@ class AsyncClient:
         await self._client.close()
 
 
-def sort_objects(objs: List[r.Resource], by: str="kind", reverse=False) -> List[r.Resource]:
-    """Sorts a list of resource objects by a sorting schema, returning a new list
-
-    **parameters**
-    * **objs** - list of resource objects to be sorted
-    * **by** - *(optional)* sorting schema. Possible values:
-        * **kind** - sorts by kind, ranking objects in an order that is suitable for batch-applying
-          many resources.  For example, Namespaces and ServiceAccounts are sorted ahead of
-          ClusterRoleBindings or Pods that might use them.  The reverse of this order is suitable
-          for batch-deleting.
-          See _kind_rank_function for full details on sorting
-    * **reverse** - *(optional)* if `True`, sorts in reverse order
-    """
-    if by == "kind":
-        objs = sorted(objs, key=_kind_rank_function, reverse=reverse)
-    else:
-        raise ValueError(f"Unknown sorting schema: {by}")
-    return objs
-
-
-UNKNOWN_ITEM_SORT_VALUE = 1000
-APPLY_ORDER = defaultdict(lambda: UNKNOWN_ITEM_SORT_VALUE)
-APPLY_ORDER["CustomResourceDefinition"] = 10
-APPLY_ORDER["Namespace"] = 20
-APPLY_ORDER["Secret"] = 31
-APPLY_ORDER["ServiceAccount"] = 32
-APPLY_ORDER["PersistentVolume"] = 33
-APPLY_ORDER["PersistentVolumeClaim"] = 34
-APPLY_ORDER["ConfigMap"] = 35
-APPLY_ORDER["Role"] = 41
-APPLY_ORDER["ClusterRole"] = 42
-APPLY_ORDER["RoleBinding"] = 43
-APPLY_ORDER["ClusterRoleBinding"] = 44
-# apply_order[anything_else] = unknown_item_sort_value
-
-
-def _kind_rank_function(obj: List[r.Resource]) -> int:
-    """
-    Returns an integer rank based on an objects .kind
-
-    Ranking is set to order kinds by:
-    * CRDs
-    * Namespaces
-    * Things that might be referenced by pods (Secret, ServiceAccount, PVs/PVCs, ConfigMap)
-    * RBAC
-        * Roles and ClusterRoles
-        * RoleBindings and ClusterRoleBindings
-    * Everything else (Pod, Deployment, ...)
-    """
-    return APPLY_ORDER[obj.kind]

--- a/lightkube/core/sort_objects.py
+++ b/lightkube/core/sort_objects.py
@@ -1,0 +1,55 @@
+from collections import defaultdict
+from typing import List
+from ..core import resource as r
+
+
+def sort_objects(objs: List[r.Resource], by: str = "kind", reverse: bool = False) -> List[r.Resource]:
+    """Sorts a list of resource objects by a sorting schema, returning a new list
+
+    **parameters**
+    * **objs** - list of resource objects to be sorted
+    * **by** - *(optional)* sorting schema. Possible values:
+        * **kind** - sorts by kind, ranking objects in an order that is suitable for batch-applying
+          many resources.  For example, Namespaces and ServiceAccounts are sorted ahead of
+          ClusterRoleBindings or Pods that might use them.  The reverse of this order is suitable
+          for batch-deleting.
+          See _kind_rank_function for full details on sorting
+    * **reverse** - *(optional)* if `True`, sorts in reverse order
+    """
+    if by == "kind":
+        objs = sorted(objs, key=_kind_rank_function, reverse=reverse)
+    else:
+        raise ValueError(f"Unknown sorting schema: {by}")
+    return objs
+
+
+UNKNOWN_ITEM_SORT_VALUE = 1000
+RANK_ORDER = {
+    "CustomResourceDefinition": 10,
+    "Namespace": 20,
+    "Secret": 31,
+    "ServiceAccount": 32,
+    "PersistentVolume": 33,
+    "PersistentVolumeClaim": 34,
+    "ConfigMap": 35,
+    "Role": 41,
+    "ClusterRole": 42,
+    "RoleBinding": 43,
+    "ClusterRoleBinding": 44,
+}
+
+
+def _kind_rank_function(obj: List[r.Resource]) -> int:
+    """
+    Returns an integer rank based on an objects .kind
+
+    Ranking is set to order kinds by:
+    * CRDs
+    * Namespaces
+    * Things that might be referenced by pods (Secret, ServiceAccount, PVs/PVCs, ConfigMap)
+    * RBAC
+        * Roles and ClusterRoles
+        * RoleBindings and ClusterRoleBindings
+    * Everything else (Pod, Deployment, ...)
+    """
+    return RANK_ORDER.get(obj.kind, UNKNOWN_ITEM_SORT_VALUE)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,6 @@ import respx
 
 import lightkube
 from lightkube.config.kubeconfig import KubeConfig, SingleConfig, Context, Cluster, User
-from lightkube.core.client import sort_objects
 from lightkube.resources.core_v1 import Pod, Node, Binding
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube import types
@@ -591,44 +590,4 @@ def test_apply_global(client: lightkube.Client):
     node = client.apply(Node.Status(), name='xx', field_manager='a', force=True)
     assert node.metadata.name == 'xx'
     assert req.calls[0][0].headers['Content-Type'] == "application/apply-patch+yaml"
-
-
-@pytest.fixture()
-def resources_in_apply_order():
-    mock_resource = namedtuple("resource", ("kind",))
-    resources = [
-        mock_resource(kind="CustomResourceDefinition"),
-        mock_resource(kind="Namespace"),
-        mock_resource(kind="Secret"),
-        mock_resource(kind="ServiceAccount"),
-        mock_resource(kind="PersistentVolume"),
-        mock_resource(kind="PersistentVolumeClaim"),
-        mock_resource(kind="ConfigMap"),
-        mock_resource(kind="Role"),
-        mock_resource(kind="ClusterRole"),
-        mock_resource(kind="RoleBinding"),
-        mock_resource(kind="ClusterRoleBinding"),
-        mock_resource(kind="something-else"),
-    ]
-    return resources
-
-
-@pytest.mark.parametrize(
-    "reverse",
-    [
-        False,  # Desired result in apply-friendly order
-        True,   # Desired order in delete-friendly order
-    ]
-)
-def test_sort_objects_by_kind(reverse, resources_in_apply_order):
-    """Tests that sort_objects can kind-sort objects in both apply and delete orders."""
-    resources_expected_order = resources_in_apply_order
-    if reverse:
-        resources_expected_order = list(reversed(resources_expected_order))
-
-    # Add disorder to the test input
-    resources_unordered = resources_expected_order[1:] + [resources_expected_order[0]]
-
-    result = sort_objects(resources_unordered, reverse=reverse)
-    assert result == resources_expected_order
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -598,14 +598,13 @@ def test_apply_global(client: lightkube.Client):
 
 
 @pytest.fixture
-def mocked_apply_client(client: lightkube.Client):
+def apply_client(client: lightkube.Client):
     mocked_apply = unittest.mock.MagicMock()
     client.apply = mocked_apply
     return client
 
 
-def test_apply_many(mocked_apply_client: lightkube.Client):
-    client = mocked_apply_client
+def test_apply_many(apply_client: lightkube.Client):
     field_manager = "someone"
     force = True
 
@@ -618,21 +617,21 @@ def test_apply_many(mocked_apply_client: lightkube.Client):
     expected_calls = [
         call(r, namespace=r.metadata.namespace, field_manager=field_manager, force=force)
         if isinstance(r, NamespacedResource)
-        else call(r, namespace=None, field_manager=field_manager, force=force)
+        else call(r, field_manager=field_manager, force=force)
         for r in resources
     ]
 
     # Execute with resources out of order
     resources_reversed = reversed(resources)
-    client.apply_many(resources_reversed, field_manager=field_manager, force=force)
+    apply_client.apply_many(resources_reversed, field_manager=field_manager, force=force)
 
     # Assert that apply has been called for the expected resources in the expected order
-    client.apply.assert_has_calls(expected_calls)
+    apply_client.apply.assert_has_calls(expected_calls)
 
 
 def test_sort_for_apply():
     mock_resource = namedtuple("resource", ("kind",))
-    resources_in_order = [
+    resources = [
         mock_resource(kind="CustomResourceDefinition"),
         mock_resource(kind="Namespace"),
         mock_resource(kind="Secret"),
@@ -648,9 +647,9 @@ def test_sort_for_apply():
     ]
 
     # Execute with resources out of order so that we know that we've ordered them
-    resources_out_of_order = list(reversed(resources_in_order))
+    resources_reversed = list(reversed(resources))
 
-    result = _sort_for_apply(resources_out_of_order)
-    assert result == resources_in_order
+    result = _sort_for_apply(resources_reversed)
+    assert result == resources
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -15,7 +15,7 @@ import respx
 
 import lightkube
 from lightkube.config.kubeconfig import KubeConfig, SingleConfig, Context, Cluster, User
-from lightkube.core.client import _sort_for_apply, _sort_for_delete
+from lightkube.core.client import _sort_for_apply
 from lightkube.resources.core_v1 import Pod, Node, Binding, Namespace
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube import types
@@ -609,7 +609,7 @@ def test_apply_many(mocked_apply_client: lightkube.Client):
     field_manager = "someone"
     force = True
 
-    resources_in_order = [
+    resources = [
         Namespace(kind="CustomResourceDefinition"),
         Role(kind="ConfigMap", metadata=ObjectMeta(namespace="some-namespace")),
         Pod(kind="Pod", metadata=ObjectMeta(namespace="some-namespace")),
@@ -619,11 +619,11 @@ def test_apply_many(mocked_apply_client: lightkube.Client):
         call(r, namespace=r.metadata.namespace, field_manager=field_manager, force=force)
         if isinstance(r, NamespacedResource)
         else call(r, namespace=None, field_manager=field_manager, force=force)
-        for r in resources_in_order
+        for r in resources
     ]
 
     # Execute with resources out of order
-    resources_reversed = reversed(resources_in_order)
+    resources_reversed = reversed(resources)
     client.apply_many(resources_reversed, field_manager=field_manager, force=force)
 
     # Assert that apply has been called for the expected resources in the expected order
@@ -651,60 +651,6 @@ def test_sort_for_apply():
     resources_out_of_order = list(reversed(resources_in_order))
 
     result = _sort_for_apply(resources_out_of_order)
-    assert result == resources_in_order
-
-
-@pytest.fixture
-def mocked_delete_client(client: lightkube.Client):
-    mocked_delete = unittest.mock.MagicMock()
-    client.delete = mocked_delete
-    return client
-
-
-def test_delete_many(mocked_delete_client: lightkube.Client):
-    client = mocked_delete_client
-    resource_in_order = [
-        Pod(kind="Pod", metadata=ObjectMeta(name="some-pod", namespace="some-namespace")),
-        Role(kind="ConfigMap", metadata=ObjectMeta(name="some-configmap", namespace="some-namespace")),
-        Namespace(kind="CustomResourceDefinition", metadata=ObjectMeta(name="some-namespace")),
-    ]
-
-    expected_calls = [
-        call(r, name=r.metadata.name, namespace=r.metadata.namespace)
-        if isinstance(r, NamespacedResource)
-        else call(r, name=r.metadata.name, namespace=None)
-        for r in resource_in_order
-    ]
-
-    # Execute with resources out of order
-    resources_out_of_order = reversed(resource_in_order)
-    client.delete_many(resources_out_of_order)
-
-    # Assert that delete has been called for the expected resources in the expected order
-    client.delete.assert_has_calls(expected_calls)
-
-
-def test_sort_for_delete():
-    mock_resource = namedtuple("resource", ("kind",))
-    resources_out_of_order = [
-        mock_resource(kind="CustomResourceDefinition"),
-        mock_resource(kind="Namespace"),
-        mock_resource(kind="Secret"),
-        mock_resource(kind="ServiceAccount"),
-        mock_resource(kind="PersistentVolume"),
-        mock_resource(kind="PersistentVolumeClaim"),
-        mock_resource(kind="ConfigMap"),
-        mock_resource(kind="Role"),
-        mock_resource(kind="ClusterRole"),
-        mock_resource(kind="RoleBinding"),
-        mock_resource(kind="ClusterRoleBinding"),
-        mock_resource(kind="something-else"),
-    ]
-
-    # Execute with resources out of order so that we know that we've ordered them
-    resources_in_order = list(reversed(resources_out_of_order))
-
-    result = _sort_for_delete(resources_out_of_order)
     assert result == resources_in_order
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,5 @@
 import unittest.mock
 import warnings
-from collections import namedtuple
-from unittest.mock import call
-
-from lightkube.core.resource import NamespacedResource
-from lightkube.resources.rbac_authorization_v1 import Role
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -15,8 +10,7 @@ import respx
 
 import lightkube
 from lightkube.config.kubeconfig import KubeConfig, SingleConfig, Context, Cluster, User
-from lightkube.core.client import _sort_for_apply
-from lightkube.resources.core_v1 import Pod, Node, Binding, Namespace
+from lightkube.resources.core_v1 import Pod, Node, Binding
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube import types
 from lightkube.generic_resource import create_global_resource
@@ -595,61 +589,3 @@ def test_apply_global(client: lightkube.Client):
     node = client.apply(Node.Status(), name='xx', field_manager='a', force=True)
     assert node.metadata.name == 'xx'
     assert req.calls[0][0].headers['Content-Type'] == "application/apply-patch+yaml"
-
-
-@pytest.fixture
-def apply_client(client: lightkube.Client):
-    mocked_apply = unittest.mock.MagicMock()
-    client.apply = mocked_apply
-    return client
-
-
-def test_apply_many(apply_client: lightkube.Client):
-    field_manager = "someone"
-    force = True
-
-    resources = [
-        Namespace(kind="CustomResourceDefinition"),
-        Role(kind="ConfigMap", metadata=ObjectMeta(namespace="some-namespace")),
-        Pod(kind="Pod", metadata=ObjectMeta(namespace="some-namespace")),
-    ]
-
-    expected_calls = [
-        call(r, namespace=r.metadata.namespace, field_manager=field_manager, force=force)
-        if isinstance(r, NamespacedResource)
-        else call(r, field_manager=field_manager, force=force)
-        for r in resources
-    ]
-
-    # Execute with resources out of order
-    resources_reversed = reversed(resources)
-    apply_client.apply_many(resources_reversed, field_manager=field_manager, force=force)
-
-    # Assert that apply has been called for the expected resources in the expected order
-    apply_client.apply.assert_has_calls(expected_calls)
-
-
-def test_sort_for_apply():
-    mock_resource = namedtuple("resource", ("kind",))
-    resources = [
-        mock_resource(kind="CustomResourceDefinition"),
-        mock_resource(kind="Namespace"),
-        mock_resource(kind="Secret"),
-        mock_resource(kind="ServiceAccount"),
-        mock_resource(kind="PersistentVolume"),
-        mock_resource(kind="PersistentVolumeClaim"),
-        mock_resource(kind="ConfigMap"),
-        mock_resource(kind="Role"),
-        mock_resource(kind="ClusterRole"),
-        mock_resource(kind="RoleBinding"),
-        mock_resource(kind="ClusterRoleBinding"),
-        mock_resource(kind="something-else"),
-    ]
-
-    # Execute with resources out of order so that we know that we've ordered them
-    resources_reversed = list(reversed(resources))
-
-    result = _sort_for_apply(resources_reversed)
-    assert result == resources
-
-

--- a/tests/test_sort_objects.py
+++ b/tests/test_sort_objects.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 import pytest
-from lightkube.core import sort_objects
 
 from lightkube import sort_objects
 

--- a/tests/test_sort_objects.py
+++ b/tests/test_sort_objects.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+import pytest
+from lightkube.core import sort_objects
+
+from lightkube import sort_objects
+
+
+@pytest.fixture()
+def resources_in_apply_order():
+    mock_resource = namedtuple("resource", ("kind",))
+    resources = [
+        mock_resource(kind="CustomResourceDefinition"),
+        mock_resource(kind="Namespace"),
+        mock_resource(kind="Secret"),
+        mock_resource(kind="ServiceAccount"),
+        mock_resource(kind="PersistentVolume"),
+        mock_resource(kind="PersistentVolumeClaim"),
+        mock_resource(kind="ConfigMap"),
+        mock_resource(kind="Role"),
+        mock_resource(kind="ClusterRole"),
+        mock_resource(kind="RoleBinding"),
+        mock_resource(kind="ClusterRoleBinding"),
+        mock_resource(kind="something-else"),
+    ]
+    return resources
+
+
+@pytest.mark.parametrize(
+    "reverse",
+    [
+        False,  # Desired result in apply-friendly order
+        True,   # Desired order in delete-friendly order
+    ]
+)
+def test_sort_objects_by_kind(reverse, resources_in_apply_order):
+    """Tests that sort_objects can kind-sort objects in both apply and delete orders."""
+    resources_expected_order = resources_in_apply_order
+    if reverse:
+        resources_expected_order = list(reversed(resources_expected_order))
+
+    # Add disorder to the test input
+    resources_unordered = resources_expected_order[1:] + [resources_expected_order[0]]
+
+    result = sort_objects(resources_unordered, reverse=reverse)
+    assert result == resources_expected_order


### PR DESCRIPTION
This PR proposes some helpers to address a problem with handling batches of resources.  I'm not married to the API, etc., and am happy to adjust and flesh out anything that is missing (for example, `create_many()`?), but I'm mainly curious atm whether this feature would be appreciated in lightkube or if I should finish it as a separate helper I keep elsewhere.

Working with a batch of resources has an order of operations challenge.  For example, this valid YAML contains both a `ClusterRoleBinding` and the `ClusterRole`/`ServiceAccount` it references:
```yaml
kind: ClusterRoleBinding
roleRef:
  kind: ClusterRole
  name: example-cluster-role-binding
subjects:
- kind: ServiceAccount
  name: example-service-account
...
---
kind: ClusterRole
metadata:
  name: example-cluster-role
...
---
kind: ServiceAccount
metadata:
  name: example-service-account
```
If users loop over the yaml and create the objects, they will get errors because the `ClusterRoleBinding` is created before the items it uses.  Tools like `kubectl` or `kapp` handle this for the user.

This PR is a proposal to similarly automate this issue with lightkube by adding `Client.apply_many()` and `Client.delete_many()` helpers.  They both accept iterables of resources and, before executing on them, order them in a safer order by kind.  afaict this is sufficient to avoid any conflicts, but I'm flexible if there's something missing.  