### PR TITLE
Client pod logs can now stream with or without newlines

### DIFF
--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -4,7 +4,7 @@ import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
 from ..core import resource as r
-from .generic_client import GenericSyncClient, GenericAsyncClient, transform_newlines
+from .generic_client import GenericSyncClient, GenericAsyncClient
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1

--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -417,7 +417,7 @@ class AsyncClient:
             resp = await self._client.send(req, stream=follow)
             self._client.raise_for_status(resp)
             async for line in resp.aiter_lines():
-                yield transform_newlines(newlines)(line)
+                yield line + '\n' if newlines else line
         return stream_log()
 
     @overload

--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -4,7 +4,7 @@ import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
 from ..core import resource as r
-from .generic_client import GenericSyncClient, GenericAsyncClient
+from .generic_client import GenericSyncClient, GenericAsyncClient, transform_newlines
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1
@@ -389,11 +389,11 @@ class AsyncClient:
 
     @overload
     def log(self, name:str, *, namespace: str = None, container: str = None, follow: bool = False,
-            since: int = None, tail_lines: int = None, timestamps: bool = False) -> AsyncIterable[str]:
+            since: int = None, tail_lines: int = None, timestamps: bool = False, newlines: bool = True) -> AsyncIterable[str]:
         ...
 
     def log(self, name, *, namespace=None, container=None, follow=False,
-            since=None, tail_lines=None, timestamps=False):
+            since=None, tail_lines=None, timestamps=False, newlines=True):
         """Return log lines for the given Pod
 
         **parameters**
@@ -405,6 +405,7 @@ class AsyncClient:
         * **since** - *(optional)* If set, a relative time in seconds before the current time from which to fetch logs.
         * **tail_lines** - *(optional)* If set, the number of lines from the end of the logs to fetch.
         * **timestamps** - *(optional)* If `True`, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output.
+        * **newlines** - *(optional)* If `True`, each line will end with a newline, otherwise the newlines will be stripped.
         """
         br = self._client.prepare_request(
             'get', core_v1.PodLog, name=name, namespace=namespace,
@@ -416,7 +417,7 @@ class AsyncClient:
             resp = await self._client.send(req, stream=follow)
             self._client.raise_for_status(resp)
             async for line in resp.aiter_lines():
-                yield line
+                yield transform_newlines(newlines)(line)
         return stream_log()
 
     @overload

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -3,7 +3,7 @@ import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
 from ..core import resource as r
-from .generic_client import GenericSyncClient, GenericAsyncClient
+from .generic_client import GenericSyncClient, GenericAsyncClient, transform_newlines
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1
@@ -392,11 +392,11 @@ class Client:
 
     @overload
     def log(self, name:str, *, namespace: str = None, container: str = None, follow: bool = False,
-            since: int = None, tail_lines: int = None, timestamps: bool = False) -> Iterator[str]:
+            since: int = None, tail_lines: int = None, timestamps: bool = False, newlines: bool = True) -> Iterator[str]:
         ...
 
     def log(self, name, *, namespace=None, container=None, follow=False,
-            since=None, tail_lines=None, timestamps=False):
+            since=None, tail_lines=None, timestamps=False, newlines=True):
         """Return log lines for the given Pod
 
         **parameters**
@@ -408,6 +408,7 @@ class Client:
         * **since** - *(optional)* If set, a relative time in seconds before the current time from which to fetch logs.
         * **tail_lines** - *(optional)* If set, the number of lines from the end of the logs to fetch.
         * **timestamps** - *(optional)* If `True`, add an RFC3339 or RFC3339Nano timestamp at the beginning of every line of log output.
+        * **newlines** - *(optional)* If `True`, each line will end with a newline, otherwise the newlines will be stripped.
         """
         br = self._client.prepare_request(
             'get', core_v1.PodLog, name=name, namespace=namespace,
@@ -416,7 +417,7 @@ class Client:
         req = self._client.build_adapter_request(br)
         resp = self._client.send(req, stream=follow)
         self._client.raise_for_status(resp)
-        return resp.iter_lines()
+        return map(transform_newlines(newlines), resp.iter_lines())
 
     @overload
     def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -417,7 +417,7 @@ class Client:
         req = self._client.build_adapter_request(br)
         resp = self._client.send(req, stream=follow)
         self._client.raise_for_status(resp)
-        return map(transform_newlines(newlines), resp.iter_lines())
+        return (line + '\n' if newlines else line for l in resp.iter_lines())
 
     @overload
     def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -3,7 +3,7 @@ import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
 from ..core import resource as r
-from .generic_client import GenericSyncClient, GenericAsyncClient, transform_newlines
+from .generic_client import GenericSyncClient, GenericAsyncClient
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1
@@ -417,7 +417,7 @@ class Client:
         req = self._client.build_adapter_request(br)
         resp = self._client.send(req, stream=follow)
         self._client.raise_for_status(resp)
-        return (line + '\n' if newlines else line for l in resp.iter_lines())
+        return (l + '\n' if newlines else l for l in resp.iter_lines())
 
     @overload
     def apply(self, obj: GlobalSubResource,  name: str, *, field_manager: str = None, force: bool = False) \

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -16,23 +16,12 @@ from ..types import OnErrorAction, OnErrorHandler, on_error_raise, PatchType
 
 
 ALL_NS = '*'
-NEWLINE = '\n'
 
 
 def transform_exception(e: httpx.HTTPError):
     if isinstance(e, httpx.HTTPStatusError) and e.response.headers['Content-Type'] == 'application/json':
         return ApiError(request=e.request, response=e.response)
     return e
-
-
-def transform_newlines(newlines: bool):
-    def wraps(l: str):
-        if not newlines:
-            return l.rstrip()
-        elif not l.endswith(NEWLINE):
-            return l + NEWLINE
-        return l
-    return wraps
 
 
 METHOD_MAPPING = {

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -16,12 +16,23 @@ from ..types import OnErrorAction, OnErrorHandler, on_error_raise, PatchType
 
 
 ALL_NS = '*'
+NEWLINE = '\n'
 
 
 def transform_exception(e: httpx.HTTPError):
     if isinstance(e, httpx.HTTPStatusError) and e.response.headers['Content-Type'] == 'application/json':
         return ApiError(request=e.request, response=e.response)
     return e
+
+
+def transform_newlines(newlines: bool):
+    def wraps(l: str):
+        if not newlines:
+            return l.rstrip()
+        elif not l.endswith(NEWLINE):
+            return l + NEWLINE
+        return l
+    return wraps
 
 
 METHOD_MAPPING = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asyncmock
-httpx >= 0.20.0
+httpx >= 0.24.0
 pytest
 pytest-asyncio
 respx

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     package_data={'lightkube': ['py.typed']},
     install_requires=[
         'lightkube-models >= 1.15.12.0',
-        'httpx >= 0.20.0',
+        'httpx >= 0.24.0',
         'PyYAML',
         'backports-datetime-fromisoformat;python_version<"3.7"',
         'dataclasses;python_version<"3.7"'

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -299,8 +299,8 @@ async def test_pod_log(client: lightkube.AsyncClient):
 
     respx.get("https://localhost:9443/api/v1/namespaces/default/pods/test/log?container=bla").respond(
         content=content)
-    lines = await alist(client.log('test', container="bla"))
-    assert lines == result
+    lines = await alist(client.log('test', container="bla", newlines=False))
+    assert lines == [_.strip() for _ in result]
     await client.close()
 
 @respx.mock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -565,8 +565,8 @@ def test_pod_log(client: lightkube.Client):
 
     respx.get("https://localhost:9443/api/v1/namespaces/default/pods/test/log?container=bla").respond(
         content=content)
-    lines = list(client.log('test', container="bla"))
-    assert lines == result
+    lines = list(client.log('test', container="bla", newlines=False))
+    assert lines == [_.strip() for _ in result]
 
 
 @respx.mock


### PR DESCRIPTION
Regarding upstream changes https://github.com/encode/httpx/pull/2423 lightkube should offer a way to maintain newlines while streaming pod logs 