### PR TITLE
Issue 50 - `load_all_yml` supports List objects

### DIFF
--- a/lightkube/codecs.py
+++ b/lightkube/codecs.py
@@ -87,7 +87,7 @@ def load_all_yaml(stream: Union[str, TextIO], context: dict = None, template_env
         stream = _template(stream, context=context, template_env=template_env)
 
     def _flatten(objects: Iterator) -> List[AnyResource]:
-        """Flatten resources which hae a kind = *List."""
+        """Flatten resources which have a kind = *List."""
         resources = []
         for obj in objects:
             if obj is None:

--- a/lightkube/codecs.py
+++ b/lightkube/codecs.py
@@ -92,12 +92,8 @@ def load_all_yaml(stream: Union[str, TextIO], context: dict = None, template_env
         for obj in objects:
             if obj is None:
                 continue
-            if (
-                isinstance(obj, Mapping) and 
-                obj.get("kind").endswith("List") and 
-                (items := obj.get("items"))
-            ):
-                resources += _flatten(items)
+            if isinstance(obj, Mapping) and obj.get("kind").endswith("List"):
+                resources += _flatten(obj.get("items") or [])
             else:
                 res = from_dict(obj)
                 resources.append(res)

--- a/lightkube/codecs.py
+++ b/lightkube/codecs.py
@@ -92,7 +92,7 @@ def load_all_yaml(stream: Union[str, TextIO], context: dict = None, template_env
         for obj in objects:
             if obj is None:
                 continue
-            if isinstance(obj, Mapping) and obj.get("kind").endswith("List"):
+            if isinstance(obj, Mapping) and obj.get("kind", "").endswith("List"):
                 resources += _flatten(obj.get("items") or [])
             else:
                 res = from_dict(obj)

--- a/tests/data/example-def-with-lists.yaml
+++ b/tests/data/example-def-with-lists.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: SecretList
+items:
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: "nginxsecret"
+    namespace: "default"
+  type: kubernetes.io/tls
+  data:
+    tls.crt: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIekNDQWdW...Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0t"
+    tls.key: "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURB...TkJnVW1VbGc9Ci0tLS0tRU5EIFBSSVZB"
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: myapp.com/v1
+  kind: Mydb
+  metadata:
+    name: bla
+    a: xx
+    b: yy
+---
+apiVersion: v1
+kind: ServiceList
+items:
+- apiVersion: v1
+  kind: ServiceList
+  metadata: {}
+  items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: my-nginx
+      labels:
+        run: my-nginx
+    spec:
+      type: NodePort
+      ports:
+      - port: 8080
+        targetPort: 80
+        protocol: TCP
+        name: http
+      - port: 443
+        protocol: TCP
+        name: https
+      selector:
+        run: my-nginx
+---
+apiVersion: apps/v1
+kind: DeploymentList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: my-nginx
+  spec:
+    selector:
+      matchLabels:
+        run: my-nginx
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          run: my-nginx
+      spec:
+        volumes:
+        - name: secret-volume
+          secret:
+            secretName: nginxsecret
+        - name: configmap-volume
+          configMap:
+            name: nginxconfigmap
+        containers:
+        - name: nginxhttps
+          image: bprashanth/nginxhttps:1.0
+          ports:
+          - containerPort: 443
+          - containerPort: 80
+          volumeMounts:
+          - mountPath: /etc/nginx/ssl
+            name: secret-volume
+          - mountPath: /etc/nginx/conf.d
+            name: configmap-volume

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -59,6 +59,10 @@ def test_from_dict():
 
 
 def test_from_dict_wrong_model():
+    # provided argument must actually be a dict
+    with pytest.raises(LoadResourceError, match='.*not a dict'):
+        codecs.from_dict([])
+
     # apiVersion and kind are required
     with pytest.raises(LoadResourceError, match=".*key 'apiVersion' missing"):
         codecs.from_dict({
@@ -123,6 +127,7 @@ def test_from_dict_not_found():
     (
             "example-def.yaml",
             "example-def-with-nulls.yaml",
+            "example-def-with-lists.yaml"
     )
 )
 def test_load_all_yaml_static(yaml_file):


### PR DESCRIPTION
As described in https://github.com/gtsystem/lightkube/issues/50, `List` resources aren't supported through the `load_all_yaml(..)` method.  This adds deep parsing for the items in a List resource, as well as raising a `LoadResourceError` on non-dict objects in `from_dict`