### PR TITLE
Use type vars for resource registration to return the same type

### DIFF
--- a/lightkube/core/resource_registry.py
+++ b/lightkube/core/resource_registry.py
@@ -1,10 +1,12 @@
 import importlib
-from typing import Union, Type, Optional
+from typing import Optional, Type, TypeVar, Union
 
 from lightkube.core import resource as res
 from lightkube.core.exceptions import LoadResourceError
 
 AnyResource = Union[res.NamespacedResource, res.GlobalResource]
+AnyResourceType = Type[AnyResource]
+AnyResourceTypeVar = TypeVar('AnyResourceTypeVar', bound=AnyResourceType)
 
 def _load_internal_resource(version, kind):
     if "/" in version:
@@ -40,7 +42,7 @@ class ResourceRegistry:
     def __init__(self):
         self._registry = {}
 
-    def register(self, resource: Type[AnyResource]) -> Type[AnyResource]:
+    def register(self, resource: AnyResourceTypeVar) -> AnyResourceTypeVar:
         """Register a custom resource
 
         **parameters**

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name='lightkube',
-    version="0.15.1",
+    version="0.15.2",
     description='Lightweight kubernetes client library',
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
`ResourceRegistry.register()` currently indicates that it returns one a type that is a subclass of `res.NamespacedResource` or `res.GlobalResource`. However, that leads type checkers to only be able to check against those definitions, losing all the type information defined on the subclass.

**Example** 
```python
from dataclasses import dataclass
from lightkube.codecs import resource_registry
from lightkube.core.resource import NamespacedResourceG

@dataclass
class ExampleClass(NamespacedResourceG):
	foo: str = 'bar'

# Currently, EC will have the type Type[Union[NamespacedResource, GlobalResource]], rather than ExampleClass
EC = resource_registry.register(ExampleClass)

ec = EC()
# Will show a type error for foo not being a defined attribute on either NamespacedResource or GlobalResource
ec.foo
```

This changes the register signature to use a TypeVar instead, to indicate that the type returned is the same type as the input
