### PR TITLE
Ensure apiVersion and kind are set for 'list' requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dist/
 *.egg-info
 site/
 htmlcov/
+.vscode
+.devcontainer
+

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -7,7 +7,6 @@ import asyncio
 
 import httpx
 
-from . import dataclasses_dict as dc_d
 from . import resource as r
 from ..config.kubeconfig import KubeConfig, SingleConfig, DEFAULT_KUBECONFIG
 from ..config import client_adapter
@@ -195,8 +194,6 @@ class GenericClient:
 
     def convert_to_resource(self, res: Type[r.Resource], item: dict) -> r.Resource:
         resource_def = r.api_info(res).resource
-        if not issubclass(res, dc_d.DataclassDictMixIn):
-            raise NotImplementedError(res)
         item.setdefault("apiVersion", resource_def.api_version)
         item.setdefault("kind", resource_def.kind)
         return res.from_dict(item, lazy=self._lazy)

--- a/lightkube/core/resource.py
+++ b/lightkube/core/resource.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, List, Optional
+from typing import NamedTuple, List, Optional, Type, Union
 from dataclasses import dataclass
 
 
@@ -25,7 +25,7 @@ class Resource:
     _api_info: ApiInfo
 
 
-def api_info(res: Resource):
+def api_info(res: Union[Resource, Type[Resource]]):
     return res._api_info
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+minversion = 6.0
+testpaths =
+    tests

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,13 @@ setup(
         'httpx >= 0.24.0',
         'PyYAML'
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "pytest-asyncio<0.17.0",
+            "respx"
+        ]
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -144,7 +144,11 @@ def test_list_namespaced(client: lightkube.Client):
     resp = {'items':[{'metadata': {'name': 'xx'}}, {'metadata': {'name': 'yy'}}]}
     respx.get("https://localhost:9443/api/v1/namespaces/default/pods").respond(json=resp)
     pods = client.list(Pod)
-    assert [pod.metadata.name for pod in pods] == ['xx', 'yy']
+    for pod, expected in zip(pods, resp["items"]):
+        assert pod.metadata is not None
+        assert pod.metadata.name == expected["metadata"]["name"]
+        assert pod.apiVersion is not None
+        assert pod.kind is not None
 
     respx.get("https://localhost:9443/api/v1/namespaces/other/pods?labelSelector=k%3Dv").respond(json=resp)
     pods = client.list(Pod, namespace="other", labels={'k': 'v'})


### PR DESCRIPTION
These changes address the issue raised [here](https://github.com/gtsystem/lightkube/issues/65).

Additionally, I:

- Added a pytest.ini (- mainly because some IDEs use this to configure their unit testing integrations)
- Added a `dev` extras to the setup.py that installs unit testing dependencies (pytest, pytest-asyncio, respx)
- Updated .gitignore to ignore files used for my personal IDE (vscode + devcontainers)