### PR TITLE
Set `__all__` in `__init__.py`

### DIFF
--- a/lightkube/__init__.py
+++ b/lightkube/__init__.py
@@ -4,3 +4,15 @@ from .core.generic_client import ALL_NS
 from .core.exceptions import ApiError, ConfigError, LoadResourceError
 from .core.sort_objects import sort_objects
 from .config.kubeconfig import KubeConfig, SingleConfig
+
+__all__ = [
+    "Client",
+    "AsyncClient",
+    "ALL_NS",
+    "ApiError",
+    "ConfigError",
+    "LoadResourceError",
+    "sort_objects",
+    "KubeConfig",
+    "SingleConfig",
+]


### PR DESCRIPTION
`__all__` not being set causes issues for those utilizing the [Pyright](https://github.com/microsoft/pyright) type-checker, since it requires that modules formally export items as mandated in [PEP 8](https://peps.python.org/pep-0008/).

>> To better support introspection, modules should explicitly declare the names in their public API using the __all__ attribute. Setting __all__ to an empty list indicates that the module has no public API.



![CleanShot 2024-07-07 at 13 33 51](https://github.com/gtsystem/lightkube/assets/41130755/49e82f3e-d235-4375-af3d-759cd26c625a)
