### PR TITLE
Support custom httpx transports

### DIFF
--- a/lightkube/config/client_adapter.py
+++ b/lightkube/config/client_adapter.py
@@ -12,15 +12,25 @@ from ..core.exceptions import ConfigError
 
 
 def Client(
-    config: SingleConfig, timeout: httpx.Timeout, trust_env: bool = True
+    config: SingleConfig,
+    timeout: httpx.Timeout,
+    trust_env: bool = True,
+    transport: httpx.BaseTransport = None,
 ) -> httpx.Client:
-    return httpx.Client(**httpx_parameters(config, timeout, trust_env))
+    return httpx.Client(
+        transport=transport, **httpx_parameters(config, timeout, trust_env)
+    )
 
 
 def AsyncClient(
-    config: SingleConfig, timeout: httpx.Timeout, trust_env: bool = True
+    config: SingleConfig,
+    timeout: httpx.Timeout,
+    trust_env: bool = True,
+    transport: httpx.AsyncBaseTransport = None,
 ) -> httpx.AsyncClient:
-    return httpx.AsyncClient(**httpx_parameters(config, timeout, trust_env))
+    return httpx.AsyncClient(
+        transport=transport, **httpx_parameters(config, timeout, trust_env)
+    )
 
 
 def httpx_parameters(config: SingleConfig, timeout: httpx.Timeout, trust_env: bool):

--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -47,6 +47,7 @@ class AsyncClient:
     * **dry_run** - *(optional)* Apply server-side dry-run and guarantee that modifications will not
         be persisted in storage. Setting this field to `True` is equivalent of passing `--dry-run=server`
         to `kubectl` commands.
+    * **transport** - *(optional)* Custom httpx transport
     """
 
     def __init__(
@@ -58,6 +59,7 @@ class AsyncClient:
         field_manager: str = None,
         trust_env: bool = True,
         dry_run: bool = False,
+        transport: httpx.AsyncBaseTransport = None,
     ):
         self._client = GenericAsyncClient(
             config,
@@ -67,6 +69,7 @@ class AsyncClient:
             field_manager=field_manager,
             trust_env=trust_env,
             dry_run=dry_run,
+            transport=transport,
         )
 
     @property

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -52,6 +52,7 @@ class Client:
     * **dry_run** - *(optional)* Apply server-side dry-run and guarantee that modifications will not
         be persisted in storage. Setting this field to `True` is equivalent of passing `--dry-run=server`
         to `kubectl` commands.
+    * **transport** - *(optional)* Custom httpx transport
     """
 
     def __init__(
@@ -63,6 +64,7 @@ class Client:
         field_manager: str = None,
         trust_env: bool = True,
         dry_run: bool = False,
+        transport: httpx.BaseTransport = None,
     ):
         self._client = GenericSyncClient(
             config,
@@ -72,6 +74,7 @@ class Client:
             field_manager=field_manager,
             trust_env=trust_env,
             dry_run=dry_run,
+            transport=transport,
         )
 
     @property

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -84,6 +84,7 @@ class GenericClient:
         trust_env: bool = True,
         field_manager: str = None,
         dry_run: bool = False,
+        transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport] = None,
     ):
         self._timeout = httpx.Timeout(10) if timeout is None else timeout
         self._watch_timeout = httpx.Timeout(self._timeout)
@@ -97,7 +98,9 @@ class GenericClient:
             config = config.get()
 
         self.config = config
-        self._client = self.AdapterClient(config, timeout, trust_env=trust_env)
+        self._client = self.AdapterClient(
+            config, timeout, trust_env=trust_env, transport=transport
+        )
         self._field_manager = field_manager
         self._dry_run = dry_run
         self.namespace = namespace if namespace else config.namespace

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name='lightkube',
-    version="0.15.4",
+    version="0.15.5",
     description='Lightweight kubernetes client library',
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -74,7 +74,8 @@ def test_client_httpx_attributes(user_auth, httpx_async_client, kubeconfig):
         verify=True,
         cert=None,
         auth=user_auth.return_value,
-        trust_env=False
+        trust_env=False,
+        transport=None,
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -113,7 +113,8 @@ def test_client_httpx_attributes(user_auth, httpx_client, kubeconfig):
         verify=True,
         cert=None,
         auth=user_auth.return_value,
-        trust_env=False
+        trust_env=False,
+        transport=None,
     )
 
 


### PR DESCRIPTION
Background: I want to improve resilience of watch to network problems.  Watch is a unidirectional protocol, and may remain idle for a long time, so I'd like to see continuous heartbeats when no events are generated, and fail-fast when the stream broke up.

- httpx transports can solve the heartbeat part, e.g. I can enable TCP keepalive on sockets for HTTP 1 connections, or send HTTP/2 pings manually for more control.
- Another part is that I would have to restart the list+watch sequence (or use `sendInitialEvents` on supported clusters), but our `list` implementation does not return `resourceVersion` on the last chunk (e.g. the `PodList` object); currently I use max of all versions in the list, but this is of course not accurate.  Maybe we can change the interface, but I haven't sorted out this part now.

This pr is the transport part.