### PR TITLE
BugFix: Check if the returned ExecCredential has `env` field

### DIFF
--- a/lightkube/config/client_adapter.py
+++ b/lightkube/config/client_adapter.py
@@ -93,7 +93,8 @@ class ExecAuth(httpx.Auth):
                 f"auth exec api version {exec.apiVersion} not implemented"
             )
         cmd_env_vars = dict(os.environ)
-        cmd_env_vars.update((var.name, var.value) for var in exec.env)
+        if exec.env:
+            cmd_env_vars.update((var.name, var.value) for var in exec.env)
         # TODO: add support for passing KUBERNETES_EXEC_INFO env var
         # https://github.com/kubernetes/community/blob/master/contributors/design-proposals/auth/kubectl-exec-plugins.md
         args = exec.args if exec.args else []


### PR DESCRIPTION
The [ExecConfig](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#ExecConfig) under the Kubeconfig contains an `env` field. The [kubelogin](https://github.com/Azure/kubelogin) command of azure is populating this field with null instead of an empty dictionary.

This causes an error: `TypeError: 'NoneType' object is not iterable`.

A quick and easy fix is to do a check if this variable is set.