### PR TITLE
Add resourceVersion to list result

### DIFF
--- a/docs/list-watch.md
+++ b/docs/list-watch.md
@@ -1,0 +1,24 @@
+# List-Watch pattern
+
+As documented in [section "Efficient detection of
+changes"](https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes)
+in kubernetes reference, we can use the `resourceVersion` from a list
+response in a subsequent watch request, to reliably receive changes
+since the list operation.  In lightkube this information is available
+on the object returned from `list()`:
+
+```python
+seen_pods = {}
+async for pod in (podlist := client.list(Pod)):
+    seen_pods[pod.metadata.name] = pod
+async for event, pod in client.watch(Pod, resource_version=podlist.resourceVersion):
+    match event:
+        case "ADDED" | "MODIFIED":
+            seen_pods[pod.metadata.name] = pod
+        case "DELETED":
+            del seen_pods[pod.metadata.name]
+```
+
+Note that the field `resourceVersion` is only available after
+iteration started, and will raise `lightkube.NotReadyError` if it is
+accessed before iterating the result.

--- a/lightkube/__init__.py
+++ b/lightkube/__init__.py
@@ -1,7 +1,7 @@
 from .core.client import Client
 from .core.async_client import AsyncClient
 from .core.generic_client import ALL_NS
-from .core.exceptions import ApiError, ConfigError, LoadResourceError
+from .core.exceptions import ApiError, NotReadyError, ConfigError, LoadResourceError
 from .core.sort_objects import sort_objects
 from .config.kubeconfig import KubeConfig, SingleConfig
 
@@ -10,6 +10,7 @@ __all__ = [
     "AsyncClient",
     "ALL_NS",
     "ApiError",
+    "NotReadyError",
     "ConfigError",
     "LoadResourceError",
     "sort_objects",

--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -12,7 +12,7 @@ import httpx
 
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from ..core import resource as r
-from .generic_client import GenericAsyncClient
+from .generic_client import GenericAsyncClient, ListAsyncIterator
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1
@@ -234,7 +234,7 @@ class AsyncClient:
         chunk_size: int = None,
         labels: LabelSelector = None,
         fields: FieldSelector = None,
-    ) -> AsyncIterable[GlobalResource]: ...
+    ) -> ListAsyncIterator[GlobalResource]: ...
 
     @overload
     def list(
@@ -245,7 +245,7 @@ class AsyncClient:
         chunk_size: int = None,
         labels: LabelSelector = None,
         fields: FieldSelector = None,
-    ) -> AsyncIterable[NamespacedResource]: ...
+    ) -> ListAsyncIterator[NamespacedResource]: ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
         """Return an iterator of objects matching the selection criteria.

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -13,7 +13,7 @@ import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
 from ..core import resource as r
-from .generic_client import GenericSyncClient
+from .generic_client import GenericSyncClient, ListIterator
 from ..core.exceptions import ConditionError, ObjectDeleted
 from ..types import OnErrorHandler, PatchType, CascadeType, on_error_raise
 from .internal_resources import core_v1
@@ -237,7 +237,7 @@ class Client:
         chunk_size: int = None,
         labels: LabelSelector = None,
         fields: FieldSelector = None,
-    ) -> Iterator[GlobalResource]: ...
+    ) -> ListIterator[GlobalResource]: ...
 
     @overload
     def list(
@@ -248,7 +248,7 @@ class Client:
         chunk_size: int = None,
         labels: LabelSelector = None,
         fields: FieldSelector = None,
-    ) -> Iterator[NamespacedResource]: ...
+    ) -> ListIterator[NamespacedResource]: ...
 
     def list(self, res, *, namespace=None, chunk_size=None, labels=None, fields=None):
         """Return an iterator of objects matching the selection criteria.

--- a/lightkube/core/exceptions.py
+++ b/lightkube/core/exceptions.py
@@ -15,6 +15,20 @@ class ConfigError(Exception):
     pass
 
 
+class NotReadyError(Exception):
+    """
+    Some information is not ready yet.
+    """
+
+    def __init__(self, name: str, message: str) -> None:
+        super().__init__()
+        self.name = name
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"{self.name} is not ready yet: {self.message}"
+
+
 class ApiError(httpx.HTTPStatusError):
     status: "meta_v1.Status"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Selectors: selectors.md
       - Generic Resources: generic-resources.md
       - Load/Dump Objects: codecs.md
+      - List-Watch Pattern: list-watch.md
 
 extra_css:
   - css/custom.css


### PR DESCRIPTION
Hi, this is meant to supersede #84 by incorporating review suggestions.  But I chose to raise an exception instead of triggering a fetch: it feels more intuitive to me when we say `thelist.resourceVersion` instead of `await thelist.getResourceVersion()`, where the latter feels like it would always start some operation.  Adding it as an immediate attribute does not preclude us adding a `getResourceVersion` later if a user really wants to know the version before pulling items.