### PR TITLE
Support httpx proxy configuration

### DIFF
--- a/lightkube/config/client_adapter.py
+++ b/lightkube/config/client_adapter.py
@@ -17,9 +17,10 @@ def Client(
     timeout: httpx.Timeout,
     trust_env: bool = True,
     transport: httpx.BaseTransport = None,
+    proxy: str = None,
 ) -> httpx.Client:
     return httpx.Client(
-        transport=transport, **httpx_parameters(config, timeout, trust_env)
+        transport=transport, **httpx_parameters(config, timeout, proxy, trust_env)
     )
 
 
@@ -28,15 +29,17 @@ def AsyncClient(
     timeout: httpx.Timeout,
     trust_env: bool = True,
     transport: httpx.AsyncBaseTransport = None,
+    proxy: str = None,
 ) -> httpx.AsyncClient:
     return httpx.AsyncClient(
-        transport=transport, **httpx_parameters(config, timeout, trust_env)
+        transport=transport, **httpx_parameters(config, timeout, proxy, trust_env)
     )
 
 
-def httpx_parameters(config: SingleConfig, timeout: httpx.Timeout, trust_env: bool):
+def httpx_parameters(config: SingleConfig, timeout: httpx.Timeout, proxy, trust_env: bool):
     return dict(
         timeout=timeout,
+        proxy=proxy,
         base_url=config.cluster.server,
         verify=verify_cluster(config.cluster, config.user, config.abs_file, trust_env=trust_env),
         auth=user_auth(config.user),

--- a/lightkube/config/client_adapter.py
+++ b/lightkube/config/client_adapter.py
@@ -36,7 +36,7 @@ def AsyncClient(
     )
 
 
-def httpx_parameters(config: SingleConfig, timeout: httpx.Timeout, proxy, trust_env: bool):
+def httpx_parameters(config: SingleConfig, timeout: httpx.Timeout, proxy: str, trust_env: bool):
     return dict(
         timeout=timeout,
         proxy=proxy,

--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -46,7 +46,8 @@ class AsyncClient:
       dry_run: Apply server-side dry-run and guarantee that modifications will not
           be persisted in storage. Setting this field to `True` is equivalent of passing `--dry-run=server`
           to `kubectl` commands.
-      transport: Custom httpx transport
+      transport: Custom httpx transport.
+      proxy: HTTP proxy for the httpx client.
     """
 
     def __init__(
@@ -59,6 +60,7 @@ class AsyncClient:
         trust_env: bool = True,
         dry_run: bool = False,
         transport: httpx.AsyncBaseTransport = None,
+        proxy: str = None,
     ):
         self._client = GenericAsyncClient(
             config,
@@ -69,6 +71,7 @@ class AsyncClient:
             trust_env=trust_env,
             dry_run=dry_run,
             transport=transport,
+            proxy=proxy,
         )
 
     @property

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -51,7 +51,8 @@ class Client:
       dry_run: Apply server-side dry-run and guarantee that modifications will not
         be persisted in storage. Setting this field to `True` is equivalent of passing `--dry-run=server`
         to `kubectl` commands.
-      transport: Custom httpx transport
+      transport: Custom httpx transport.
+      proxy: HTTP proxy for the httpx client.
     """
 
     def __init__(
@@ -64,6 +65,7 @@ class Client:
         trust_env: bool = True,
         dry_run: bool = False,
         transport: httpx.BaseTransport = None,
+        proxy: str = None,
     ):
         self._client = GenericSyncClient(
             config,
@@ -74,6 +76,7 @@ class Client:
             trust_env=trust_env,
             dry_run=dry_run,
             transport=transport,
+            proxy=proxy,
         )
 
     @property

--- a/lightkube/core/generic_client.py
+++ b/lightkube/core/generic_client.py
@@ -149,6 +149,7 @@ class GenericClient:
         field_manager: str = None,
         dry_run: bool = False,
         transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport] = None,
+        proxy: str = None,
     ):
         self._timeout = httpx.Timeout(10) if timeout is None else timeout
         self._watch_timeout = httpx.Timeout(self._timeout)
@@ -163,7 +164,7 @@ class GenericClient:
 
         self.config = config
         self._client = self.AdapterClient(
-            config, timeout, trust_env=trust_env, transport=transport
+            config, timeout, trust_env=trust_env, transport=transport, proxy=proxy
         )
         self._field_manager = field_manager
         self._dry_run = dry_run

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setup(
     name='lightkube',
-    version="0.17.1",
+    version="0.17.2",
     description='Lightweight kubernetes client library',
     long_description=Path("README.md").read_text(),
     long_description_content_type="text/markdown",

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -77,6 +77,7 @@ def test_client_httpx_attributes(verify_cluster, user_auth, httpx_async_client, 
         auth=user_auth.return_value,
         trust_env=False,
         transport=None,
+        proxy=None,
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -117,6 +117,7 @@ def test_client_httpx_attributes(verify_cluster, user_auth, httpx_client, kubeco
         auth=user_auth.return_value,
         trust_env=False,
         transport=None,
+        proxy=None,
     )
 
 


### PR DESCRIPTION
Background: I want to improve the configurability of the client executing requests towards k8s. Currently LightCube does not expose the proxy configuration capabilities of httpx, the library used to execute http queries. Some network configurations might depend on this configuration and exposing these capabilities extends the functionality of LightCube.

Technically it is possible to use a proxy configuration without this change. Httpx has a defaulting property where a proxy can be inferred from the systems environment properties. This is inflexible when a proxy is configured in runtime and one does not want to affect other systems running in the same environment.

Currently only the simple proxy configuration support was enabled. If required the whole proxy handling capability can be supported with little work. Details can be found here:
https://www.python-httpx.org/advanced/proxies/

The changes of this PR should not affect existing functionality and adds to the capabilities of LightKube.