### PR TITLE
Fix type of proxy argument for `Client`

### DIFF
--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -1,14 +1,4 @@
-from typing import (
-    Type,
-    Iterator,
-    TypeVar,
-    Union,
-    overload,
-    Dict,
-    Tuple,
-    List,
-    Iterable,
-)
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple, Type, TypeVar, Union, overload
 import httpx
 from ..config.kubeconfig import SingleConfig, KubeConfig
 from .. import operators
@@ -65,7 +55,7 @@ class Client:
         trust_env: bool = True,
         dry_run: bool = False,
         transport: httpx.BaseTransport = None,
-        proxy: str = None,
+        proxy: Optional[str] = None,
     ):
         self._client = GenericSyncClient(
             config,


### PR DESCRIPTION
It seems that the type of Proxy for core.Client is wrong, it should also allow None, as that's the default value.