### PR TITLE
Fix httpx.ResponseNotRead if streaming unready pod logs

### DIFF
--- a/lightkube/core/async_client.py
+++ b/lightkube/core/async_client.py
@@ -657,7 +657,7 @@ class AsyncClient:
         timestamps=False,
         newlines=True,
     ):
-        """Return log lines for the given Pod. Raise `lightkube.ApiError` if the Pod doesn't exist.
+        """Return log lines for the given Pod. Raise `lightkube.ApiError` if the Pod doesn't exist or has not yet started.
 
         Parameters:
           name: Name of the Pod.
@@ -686,6 +686,9 @@ class AsyncClient:
 
         async def stream_log():
             resp = await self._client.send(req, stream=follow)
+            if resp.is_error and follow:
+                # The body must be read into memory before accessing it when building the exception.
+                resp.read()
             self._client.raise_for_status(resp)
             async for line in resp.aiter_lines():
                 yield line + "\n" if newlines else line

--- a/lightkube/core/client.py
+++ b/lightkube/core/client.py
@@ -650,7 +650,7 @@ class Client:
         timestamps=False,
         newlines=True,
     ):
-        """Return log lines for the given Pod. Raise `lightkube.ApiError` if the Pod doesn't exist.
+        """Return log lines for the given Pod. Raise `lightkube.ApiError` if the Pod doesn't exist or has not yet started.
 
         Parameters:
             name: Name of the Pod.
@@ -677,6 +677,9 @@ class Client:
         )
         req = self._client.build_adapter_request(br)
         resp = self._client.send(req, stream=follow)
+        if resp.is_error and follow:
+            # The body must be read into memory before accessing it when building the exception.
+            resp.read()
         self._client.raise_for_status(resp)
         return (l + "\n" if newlines else l for l in resp.iter_lines())
 


### PR DESCRIPTION
### Description

If calling `Client.log()` on a Pod that exists but the container has not started yet, the Kubernetes API will return `400`, considering that a client error.

Lightkube will try to convert that `httpx.HTTPStatusError` into an `ApiError`. While doing so, it will read the response body for the Status object that the Kubernetes API returns on errors.

However, if the `follow` parameter is `True`, this function will set `stream` to `True`, which will instruct httpx to delay reading of the response. Then, when lightkube attempts to parse the response body, httpx errors because it has not yet been read.

To fix this, simply read the body before creating the error. Now an `ApiError` will be raised with the status set to `400` as expected.

### Stack trace
```
Traceback (most recent call last):
  File "project/venv/lib/python3.13/site-packages/lightkube/core/generic_client.py", line 300, in raise_for_status
    resp.raise_for_status()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "project/venv/lib/python3.13/site-packages/httpx/_models.py", line 829, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '400 Bad Request' for url 'https://my-cluster/api/v1/namespaces/tests-local/pods/test-65bfbcdcb7-stf5l/log?timestamps=true&container=test&follow=true'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "project/__main__.py", line 40, in main
    watch_container(pod, container)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "project/log_watcher.py", line 94, in watch_container
    for line in self.client.stream_pod_logs(pod, container):
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "project/kubernetes/pod_logs.py", line 75, in stream_pod_logs
    yield from self.client.log(
               ~~~~~~~~~~~~~~~^
        name=pod,
        ^^^^^^^^^
    ...<2 lines>...
        follow=True,
        ^^^^^^^^^^^^
    )
    ^
  File "project/venv/lib/python3.13/site-packages/lightkube/core/client.py", line 680, in log
    self._client.raise_for_status(resp)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "project/venv/lib/python3.13/site-packages/lightkube/core/generic_client.py", line 302, in raise_for_status
    raise transform_exception(e)
          ~~~~~~~~~~~~~~~~~~~^^^
  File "project/venv/lib/python3.13/site-packages/lightkube/core/generic_client.py", line 37, in transform_exception
    return ApiError(request=e.request, response=e.response)
  File "project/venv/lib/python3.13/site-packages/lightkube/core/exceptions.py", line 38, in __init__
    self.status = meta_v1.Status.from_dict(response.json())
                                           ~~~~~~~~~~~~~^^
  File "project/venv/lib/python3.13/site-packages/httpx/_models.py", line 832, in json
    return jsonlib.loads(self.content, **kwargs)
                         ^^^^^^^^^^^^
  File "project/venv/lib/python3.13/site-packages/httpx/_models.py", line 638, in content
    raise ResponseNotRead()
httpx.ResponseNotRead: Attempted to access streaming response content, without having called `read()`.
```

### Notes
I am not sure if this change could have any side effects. In my testing, it worked correctly in all scenarios, but I do not know if calling `resp.read()` could ever be a problem.

It looks like it could also be a problem here:
https://github.com/gtsystem/lightkube/blob/dae9a760c518e6fd8905009617320597b58ff4b5/lightkube/core/generic_client.py#L351-L353
But that the blanket `except Exception` is probably masking this issue, and might not be a problem then.